### PR TITLE
Bump exporter to 1.2.0

### DIFF
--- a/charts/jenkins-wiki-exporter/values.yaml
+++ b/charts/jenkins-wiki-exporter/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: halkeye/jenkins-wiki-exporter
-  tag: v1.1.2
+  tag: v1.2.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
cc @zbynek for https://github.com/jenkins-infra/jenkins-wiki-exporter/pull/27