### PR TITLE
Bump datadog/nginx-ingress/loki helm chart

### DIFF
--- a/helmfile.d/datadog.yaml
+++ b/helmfile.d/datadog.yaml
@@ -2,7 +2,7 @@ releases:
     - name: datadog
       namespace: datadog
       chart: stable/datadog
-      version: 1.24.0
+      version: 1.38.3
       wait: true
       timeout: 300
       atomic: true

--- a/helmfile.d/loki.yaml
+++ b/helmfile.d/loki.yaml
@@ -2,7 +2,7 @@ releases:
     - name: loki
       namespace: loki
       chart: loki/loki
-      version: 0.14.1
+      version: 0.17.2
       wait: true
       timeout: 100
       force: true
@@ -12,7 +12,7 @@ releases:
     - name: promtail
       namespace: loki
       chart: loki/promtail
-      version: 0.12.0
+      version: 0.13.1
       wait: true
       timeout: 100
       force: true

--- a/helmfile.d/nginx-ingress.yaml
+++ b/helmfile.d/nginx-ingress.yaml
@@ -2,7 +2,7 @@ releases:
     - name: public-nginx-ingress
       chart: stable/nginx-ingress
       namespace: kube-system
-      version: 1.4.0
+      version: 1.25.0
       wait: true
       timeout: 600
       recreatePods: true
@@ -33,7 +33,7 @@ releases:
     - name: private-nginx-ingress
       chart: stable/nginx-ingress
       namespace: kube-system
-      version: 1.4.0
+      version: 1.25.0
       wait: true
       timeout: 600
       recreatePods: true


### PR DESCRIPTION
This PR is needed in order to work with the latest helm version


> ==> Linting /tmp/204077806/datadog/1.24.0/stable/datadog/datadog
> [ERROR] Chart.yaml: apiVersion is required
> 