### PR TITLE
Re-increase plugin-site limit

### DIFF
--- a/config/default/plugin-site.yaml
+++ b/config/default/plugin-site.yaml
@@ -26,8 +26,8 @@ replicaCount: 2
 
 resources:
   limits:
-    cpu: 500m
-    memory: 1024Mi
+    cpu: 2000m
+    memory: 2048Mi
   requests:
-    cpu: 250m
-    memory: 512Mi
+    cpu: 1000m
+    memory: 1024Mi


### PR DESCRIPTION
I am re-increasing the limit  of the pluginsite as, according the monitoring, it's way too low, and containers don't start
 
![image](https://user-images.githubusercontent.com/2360224/69975897-5b213700-1528-11ea-9d1c-64d6bb9c25c1.png)
