### PR TITLE
Fix typo - remove duplicate yaml

### DIFF
--- a/config/default/jenkinsio.yaml
+++ b/config/default/jenkinsio.yaml
@@ -59,12 +59,6 @@ htmlVolume:
     shareName: jenkinsio
     readOnly: true
 
-htmlVolume:
-  azureFile: 
-    secretName: jenkinsio
-    shareName: jenkinsio
-    readOnly: true
-
 zhHtmlVolume:
   azureFile: 
     secretName: jenkinsio


### PR DESCRIPTION
should't cause any harm, noticed while looking to see why jenkins.io wasn't deploying to AKS