### PR TITLE
Enable CORS for plugin site

### DIFF
--- a/config/default/plugin-site.yaml
+++ b/config/default/plugin-site.yaml
@@ -6,6 +6,10 @@ ingress:
     "nginx.ingress.kubernetes.io/rewrite-target": /$1
     "nginx.ingress.kubernetes.io/hsts": "true"
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+    "nginx.ingress.kubernetes.io/enable-cors": "true"
+    "nginx.ingress.kubernetes.io/cors-allow-methods": "GET, OPTIONS"
+    "nginx.ingress.kubernetes.io/cors-allow-origin": "*"
+
 
   hosts:
     - host: plugins.jenkins.io


### PR DESCRIPTION
Need to be able to hit the API from front end, and easier than running my own fork.