### PR TITLE
Use grafana.publick8s.jenkins.io grafana.jenkins.io

### DIFF
--- a/config/default/grafana.yaml
+++ b/config/default/grafana.yaml
@@ -3,6 +3,7 @@ ingress:
   enabled: true
   hosts: 
     - grafana.jenkins.io
+    - grafana.publick8s.jenkins.io
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "kubernetes.io/ingress.class": "nginx"
@@ -10,6 +11,7 @@ ingress:
   tls:
     - hosts:
         - grafana.jenkins.io
+        - grafana.publick8s.jenkins.io
       secretName: grafana-cert
 
 resources:
@@ -53,7 +55,7 @@ grafana.ini:
     allow_sign_up: true
     config_file: /etc/grafana/ldap.toml
   grafana_net:
-    url: https://grafana.jenkins.io
+    url: https://grafana.publick8s.jenkins.io
   log:
     mode: console
     level: info


### PR DESCRIPTION
Update the grafana service running on publick8s to use the correct DNS [record](https://github.com/jenkins-infra/azure/blob/7fa3fda31020879e5453fc76a44e3effce4ee6df/plans/dns_jenkinsio.tf#L69)