### PR TITLE
Use a forked version of the gatsby image that disabled openfds

### DIFF
--- a/charts/plugin-site/templates/deployment-frontend.yaml
+++ b/charts/plugin-site/templates/deployment-frontend.yaml
@@ -30,8 +30,8 @@ spec:
                 containerPort: {{ .Values.frontend.port }}
                 protocol: TCP
           env:
-            - name: REST_API_URL
-              value: {{ .Values.restApiUrl }}
+            - name: DISABLE_FILE_CACHE
+              value: "true"
           livenessProbe:
               httpGet:
                   path: /

--- a/charts/plugin-site/values.yaml
+++ b/charts/plugin-site/values.yaml
@@ -21,8 +21,8 @@ backend:
 frontend:
   replicaCount: 1
   image:
-    repository: gatsbyjs/gatsby
-    tag: latest
+    repository: halkeye/gatsby
+    tag: disable-open-fd
     pullPolicy: Always
   port: 80
   resources:


### PR DESCRIPTION
@olblak I can't reproduce the problem locally, so giving you two options.

This one just disables the openfd item