### PR TITLE
Switch to the nginx for serving plugin site content

### DIFF
--- a/charts/plugin-site/templates/deployment-frontend.yaml
+++ b/charts/plugin-site/templates/deployment-frontend.yaml
@@ -12,6 +12,8 @@ spec:
   template:
     metadata:
       labels: {{ include "plugin-site.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -49,6 +51,8 @@ spec:
           volumeMounts:
             - name: html
               mountPath: /pub
+            - name: config
+              mountPath: /etc/nginx/conf.d
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
@@ -66,3 +70,6 @@ spec:
       volumes:
         - name: html
 {{ toYaml .Values.htmlVolume | indent 10 }}
+        - name: config
+          configMap:
+            name: {{ include "plugin-site.fullname" . }}-nginx

--- a/charts/plugin-site/templates/nginx-configmap.yaml
+++ b/charts/plugin-site/templates/nginx-configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "plugin-site.fullname" . }}-nginx
+  labels: {{ include "plugin-site.labels" . | nindent 4 }}
+data:
+  default.conf: |
+    server {
+      listen 80;
+      root /pub;
+
+      index index.html;
+      autoindex off;
+      charset utf-8;
+
+      error_page 404 /404.html;
+
+      location ~* \.(html)$ {
+        add_header Cache-Control "no-store";
+        expires    off;
+      }
+
+      location ~* \.(ico|jpg|jpeg|png|gif|svg|js|jsx|css|less|swf|eot|ttf|otf|woff|woff2)$ {
+        add_header Cache-Control "public";
+        expires +1y;
+      }
+
+      rewrite ^([^.]*[^/])$ $1/ permanent;
+
+      try_files $uri $uri/ $uri/index.html =404;
+    }

--- a/charts/plugin-site/values.yaml
+++ b/charts/plugin-site/values.yaml
@@ -21,16 +21,16 @@ backend:
 frontend:
   replicaCount: 1
   image:
-    repository: gatsbyjs/gatsby
-    tag: latest
-    pullPolicy: Always
+    repository: nginx
+    tag: 1.17.7-alpine
+    pullPolicy: IfNotPresent
   port: 80
   resources:
     limits:
-      cpu: 10m
+      cpu: 100m
       memory: 32Mi
     requests:
-      cpu: 10m
+      cpu: 100m
       memory: 32Mi
 
 imagePullSecrets: []


### PR DESCRIPTION
From what I can see online (https://www.ruby-forum.com/t/nginx-0-7-59-open-file-cache-and-nfs/169930/6 and other pages)
the open file cache messes with network filesystems a bit, so disable
that performance fix

---

@olblak I can't reproduce the problem locally, so giving you two options.

This one just goes back to regular nginx