### PR TITLE
[plugin-site] rename env variable to GITHUB_SECRET to match code

### DIFF
--- a/charts/plugin-site/templates/deployment-backend.yaml
+++ b/charts/plugin-site/templates/deployment-backend.yaml
@@ -31,7 +31,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "plugin-site.fullname" . }}
                   key: github_client_id
-            - name: GITHUB_CLIENT_SECRET
+            - name: GITHUB_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "plugin-site.fullname" . }}


### PR DESCRIPTION
as far as I can tell from https://github.com/jenkins-infra/plugin-site-api/blob/master/src/main/java/io/jenkins/plugins/services/impl/GithubExtractor.java#L40 the env variable should be GITHUB_SECRET