### PR TITLE
Increase wiki exporter CPU limits

### DIFF
--- a/charts/jenkins-wiki-exporter/values.yaml
+++ b/charts/jenkins-wiki-exporter/values.yaml
@@ -41,7 +41,7 @@ resources:
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
-    cpu: 100m
+    cpu: 300m
     memory: 128Mi
   requests:
     cpu: 100m


### PR DESCRIPTION
When exporting heavy wiki pages or lots in a short time the current CPU limit is not enough