### PR TITLE
Deploy Mirrorbits

### DIFF
--- a/charts/mirrorbits/.helmignore
+++ b/charts/mirrorbits/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 appVersion: "v0.5.1"
-description: A Helm chart for Kubernetes
+description: Mirrobits helm chart for Kubernetes
 name: mirrorbits
 version: 0.1.0
 maintainers:
-  - jenkins-infra/kubernetes
+  - name: olblak
+    email: me@olblak.com

--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+appVersion: "v0.5.1"
+description: A Helm chart for Kubernetes
+name: mirrorbits
+version: 0.1.0
+maintainers:
+  - jenkins-infra/kubernetes

--- a/charts/mirrorbits/README.md
+++ b/charts/mirrorbits/README.md
@@ -1,0 +1,32 @@
+# Mirrorbits
+
+This chart deploys [mirrorbits](https://github.com/etix/mirrorbits)
+
+A "Quick Start" is available on [etix/mirrorbits](repository)
+
+Docker image used in this chart is defined on [olblak/mirrorbits](https://github.com/olblak/mirrorbits)
+
+## Settings
+
+Most important configuration are:
+
+```
+# mirrorbits.conf - https://github.com/etix/mirrorbits/blob/master/mirrorbits.conf
+mirrorbits: |
+  RedisAddress: 10.0.0.1:6379 
+  RedisPassword: supersecure
+  RedisDB: 0
+  ...
+
+To mount an azure file storage at /srv/repo
+storageAccountName:
+storageAccountKey:
+```
+
+## Requirements
+This chart requires a redis database which can be deployed with the redis helm [chart](https://github.com/helm/charts/tree/master/stable/redis)
+
+## Links
+
+* [Mirrorbits](https://github.com/etix/mirrorbits) - Upstream project
+* [Mirrorbits](https://github.com/olblak/mirrorbits) - Docker Image

--- a/charts/mirrorbits/README.md
+++ b/charts/mirrorbits/README.md
@@ -8,20 +8,40 @@ Docker image used in this chart is defined on [olblak/mirrorbits](https://github
 
 ## Settings
 
-Most important configuration are:
-
 ```
-# mirrorbits.conf - https://github.com/etix/mirrorbits/blob/master/mirrorbits.conf
-mirrorbits: |
-  RedisAddress: 10.0.0.1:6379 
-  RedisPassword: supersecure
-  RedisDB: 0
-  ...
+`replicaCount`
+`image.reposotiry`
+`image.tag`
+`image.pullPolicy`
+`nameOverride`:
+`fullnameOverride`:
+`imagePullSecrets`:
+`serviceAccount.create`:
+`serviceAccount.name`:
+`securityContext`:
+`podSecurityContext`:
+`service.type`:
+`service.port`:
+`ingress.enabled`:
+`ingress.annotations`:
+`ingress.hosts`
+`ingress.tls`
+`resources.limits.cpu`:
+`resources.limits.memory`:
+`resources.requests.cpu`:
+`resources.requests.memory`:
+`nodeSelector`:
+`tolerations`:
+`affinity`:
+`mirrorbits.conf`: "Define the mirrorbits.conf data"
+`repository.name`: "Enforce repository resource name used for secret-persistentVolume - persistentvolumeClaim"
+`repository.persistentVolumeClaim.enabled`: _"Enable the persistentVolumeClaim for the repository directory"_
+`repository.persistentVolumeClaim.spec`: _Define the persistentVolumeClaim Spec_
+`repository.persistentVolume.enabled`: _Enable the persistentVolume for repository directory_
+`repository.persistentVolume.spec`: _Define the persistentVolume Spec_
+`repository.secrets.enabled`: _Enable the secrets resource for repository directory_
+`repository.secrets.spec`: _Define the secret data_
 
-To mount an azure file storage at /srv/repo
-storageAccountName:
-storageAccountKey:
-```
 
 ## Requirements
 This chart requires a redis database which can be deployed with the redis helm [chart](https://github.com/helm/charts/tree/master/stable/redis)

--- a/charts/mirrorbits/README.md
+++ b/charts/mirrorbits/README.md
@@ -1,18 +1,22 @@
 # Mirrorbits
 
-This chart deploys [mirrorbits](https://github.com/etix/mirrorbits)
+This chart deploys two services [mirrorbits](https://github.com/etix/mirrorbits) and a simple nginx service that return every file
 
 A "Quick Start" is available on [etix/mirrorbits](repository)
 
-Docker image used in this chart is defined on [olblak/mirrorbits](https://github.com/olblak/mirrorbits)
+Docker image used in this chart is defined from [olblak/mirrorbits](https://github.com/olblak/mirrorbits)
+
 
 ## Settings
 
 ```
 `replicaCount`
-`image.reposotiry`
-`image.tag`
-`image.pullPolicy`
+`image.mirrorbits.reposotiry`
+`image.mirrorbits.tag`
+`image.mirrorbits.pullPolicy`
+`image.files.reposotiry`
+`image.files.tag`
+`image.files.pullPolicy`
 `nameOverride`:
 `fullnameOverride`:
 `imagePullSecrets`:
@@ -41,10 +45,31 @@ Docker image used in this chart is defined on [olblak/mirrorbits](https://github
 `repository.persistentVolume.spec`: _Define the persistentVolume Spec_
 `repository.secrets.enabled`: _Enable the secrets resource for repository directory_
 `repository.secrets.spec`: _Define the secret data_
-
+```
 
 ## Requirements
 This chart requires a redis database which can be deployed with the redis helm [chart](https://github.com/helm/charts/tree/master/stable/redis)
+
+## Configuration
+
+Currently mirrorbits do not provide a way to configure mirrors through a configuration file and considering that this is not something that changes regularly, I will run the following commands once via "kubectl" exec
+
+```
+mirrorbits add -rsync rsync://mirror.serverion.com/jenkins -ftp ftp://mirror.serverion.com/jenkins -http https://mirror.serverion.com/jenkins -sponsor-name serverion -sponsor-url serverion.com -admin-email "desmond@serverion.com" -admin-name "Desmond van der Winden" serverion.com
+
+mirrorbits add -http https://mirror.esuni.jp/jenkins/ -admin-email "kuriyama@FreeBSD.org" esuni.jp
+
+mirrorbits add -http http://mirrors.tuna.tsinghua.edu.cn/jenkins/ -rsync rsync://mirrors.tuna.tsinghua.edu.cn/jenkins/ -admin-name "Yuzhi Wang" -admin-email "yuzhi.wang@tuna.tsinghua.edu.cn" tsinghua.edu.cn
+
+mirrorbits add -http https://mirror.xmission.com/jenkins/ -rsync rsync://mirror.xmission.com/jenkins/  -ftp ftp://mirror.xmission.com/jenkins/ xmission.org
+
+# jenkins not synced on rsync
+mirrorbits add -http https://ftp-nyc.osuosl.org/pub/jenkins -rsync rsync://ftp-nyc.osuosl.org/jenkins -ftp ftp://ftp-nyc.osuosl.org/pub/jenkins ftp-nyc.osuosl.org
+
+mirrorbits add -http https://ftp-chi.osuosl.org/pub/jenkins -rsync rsync://ftp-chi.osuosl.org/jenkins -ftp ftp://ftp-chi.osuosl.org/pub/jenkins ftp-chi.osuosl.org
+
+mirrorbits add -http https://ftp.yz.yamagata-u.ac.jp/pub/misc/jenkins/ -rsync rsync://ftp.yz.yamagata-u.ac.jp/pub/misc/jenkins/ -admin-name "Tomohiro Ito" -admin-email "tomohiro@yz.yamagata-u.ac.jp"  yamagata-u.ac.jp
+```
 
 ## Links
 

--- a/charts/mirrorbits/templates/NOTES.txt
+++ b/charts/mirrorbits/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mirrorbits.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mirrorbits.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mirrorbits.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mirrorbits.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080/?mirrorstats to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/mirrorbits/templates/_helpers.tpl
+++ b/charts/mirrorbits/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mirrorbits.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mirrorbits.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mirrorbits.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "mirrorbits.labels" -}}
+app.kubernetes.io/name: {{ include "mirrorbits.name" . }}
+helm.sh/chart: {{ include "mirrorbits.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mirrorbits.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "mirrorbits.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/mirrorbits/templates/configmap.files.yaml
+++ b/charts/mirrorbits/templates/configmap.files.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mirrorbits.fullname" . }}-files
+data:
+  default.conf: |
+    server {
+      listen       80;
+      server_name  localhost;
+  
+      location / {
+          autoindex on;
+          root   /usr/share/nginx/html;
+          index  index.html index.htm;
+      }
+
+      error_page  404              /404/index.html;
+  
+      # redirect server error pages to the static page /50x.html
+      #
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+          root   /usr/share/nginx/html;
+      }
+  
+    }

--- a/charts/mirrorbits/templates/deployment.files.yaml
+++ b/charts/mirrorbits/templates/deployment.files.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mirrorbits.fullname" . }}-files
+  labels:
+{{ include "mirrorbits.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount.files }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "mirrorbits.name" . }}-files
+      app.kubernetes.io/instance: {{ .Release.Name }}-files
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "mirrorbits.name" . }}-files
+        app.kubernetes.io/instance: {{ .Release.Name }}-files
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.files.repository }}:{{ .Values.image.files.tag }}"
+          imagePullPolicy: {{ .Values.image.files.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+             port: 80
+          readinessProbe:
+            tcpSocket:
+              port: 80
+          resources:
+            {{- toYaml .Values.resources.files | nindent 12 }}
+          volumeMounts:
+            - name: binary
+              mountPath: /usr/share/nginx/html
+              readOnly: true
+            - name: conf
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      volumes:
+        - name: conf
+          configMap:
+            name: {{ include "mirrorbits.fullname" . }}-files
+        - name: binary
+          persistentVolumeClaim:
+            claimName: {{ include "mirrorbits.fullname" . }}-binary

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
 {{ include "mirrorbits.labels" . | indent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.mirrorbits }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "mirrorbits.name" . }}
@@ -26,12 +26,12 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: crond
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}-cron"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.image.mirrorbits.repository }}:{{ .Values.image.mirrorbits.tag }}-cron"
+          imagePullPolicy: {{ .Values.image.mirrorbits.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.mirrorbits | nindent 12 }}
           volumeMounts:
             {{ if $.Values.repository.persistentVolumeClaim.enabled -}}
             - name: binary
@@ -40,8 +40,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.image.mirrorbits.repository }}:{{ .Values.image.mirrorbits.tag }}"
+          imagePullPolicy: {{ .Values.image.mirrorbits.pullPolicy }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -42,8 +44,10 @@ spec:
           volumeMounts:
             - name: conf
               mountPath: /etc/mirrorbits
+            {{ if $.Values.repository.persistentVolumeClaim.enabled -}}
             - name: binary
               mountPath: /srv/repo
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /?mirrorstats
@@ -73,6 +77,8 @@ spec:
             items: 
               - key: mirrorbits.conf
                 path: mirrorbits.conf
+        {{ if $.Values.repository.persistentVolumeClaim.enabled -}}
         - name: binary
           persistentVolumeClaim:
             claimName: {{ include "mirrorbits.fullname" . }}-binary
+        {{- end -}}

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -32,6 +32,11 @@ spec:
             allowPrivilegeEscalation: false
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{ if $.Values.repository.persistentVolumeClaim.enabled -}}
+            - name: binary
+              mountPath: /srv/repo
+            {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mirrorbits.fullname" . }}
+  labels:
+{{ include "mirrorbits.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "mirrorbits.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "mirrorbits.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum | trunc 63 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ template "mirrorbits.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: crond
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}-cron"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: conf
+              mountPath: /etc/mirrorbits
+            - name: binary
+              mountPath: /srv/repo
+          livenessProbe:
+            httpGet:
+              path: /?mirrorstats
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /?mirrorstats
+              port: 8080
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      volumes:
+        - name: conf
+          secret:
+            secretName: {{ include "mirrorbits.fullname" . }}
+            items: 
+              - key: mirrorbits.conf
+                path: mirrorbits.conf
+        - name: binary
+          persistentVolumeClaim:
+            claimName: {{ include "mirrorbits.fullname" . }}-binary

--- a/charts/mirrorbits/templates/ingress.yaml
+++ b/charts/mirrorbits/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
             backend:
               serviceName: {{ $fullName }}-files
               servicePort: 80
-          - path: /.*(.deb|.war|.rpm|.msi)$
+          - path: /.*(.deb|.war|.rpm|.msi|.pkg|.sha256|.md5sum|.zip|.gz|.pdf|.json|.svg|.sh|.jpeg|.ico|.png|.html)$
             backend:
               serviceName: {{ $fullName }}
               servicePort: 80

--- a/charts/mirrorbits/templates/ingress.yaml
+++ b/charts/mirrorbits/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "mirrorbits.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "mirrorbits.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/mirrorbits/templates/ingress.yaml
+++ b/charts/mirrorbits/templates/ingress.yaml
@@ -13,6 +13,7 @@ metadata:
 {{ include "mirrorbits.labels" . | indent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
@@ -31,11 +32,14 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-        {{- range .paths }}
-          - path: {{ . }}
+          # First match policy
+          - path: /
+            backend:
+              serviceName: {{ $fullName }}-files
+              servicePort: 80
+          - path: /.*(.deb|.war|.rpm|.msi)$
             backend:
               serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-        {{- end }}
+              servicePort: 80
   {{- end }}
 {{- end }}

--- a/charts/mirrorbits/templates/persistentVolume.yaml
+++ b/charts/mirrorbits/templates/persistentVolume.yaml
@@ -1,24 +1,11 @@
+{{ if $.Values.repository.persistentVolume.enabled -}}
 ---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ include "mirrorbits.fullname" . }}-binary
+  name: {{ $.Values.repository.name | default (printf "%s-binary" (include "mirrorbits.fullname" .)) }}
   labels:
-    data: {{ include "mirrorbits.fullname" . }}-binary
+    data: {{ $.Values.repository.name | default (printf "%s-binary" (include "mirrorbits.fullname" . )) }}
 spec:
-  capacity:
-    storage: 100Gi
-  accessModes:
-    - ReadWriteMany
-  storageClassName: azurefile
-  azureFile:
-    secretName: {{ include "mirrorbits.fullname" . }}-binary
-    shareName: {{ .Values.shareName }}
-    readOnly: true
-  mountOptions:
-  - dir_mode=0777
-  - file_mode=0777
-  - uid=101
-  - gid=101
-  - mfsymlinks
-  - nobrl
+{{ toYaml .Values.repository.persistentVolume.spec | nindent 2 }}
+{{- end -}}

--- a/charts/mirrorbits/templates/persistentVolume.yaml
+++ b/charts/mirrorbits/templates/persistentVolume.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "mirrorbits.fullname" . }}-binary
+  labels:
+    data: {{ include "mirrorbits.fullname" . }}-binary
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+  storageClassName: azurefile
+  azureFile:
+    secretName: {{ include "mirrorbits.fullname" . }}-binary
+    shareName: {{ .Values.shareName }}
+    readOnly: true
+  mountOptions:
+  - dir_mode=0777
+  - file_mode=0777
+  - uid=101
+  - gid=101
+  - mfsymlinks
+  - nobrl

--- a/charts/mirrorbits/templates/persistentVolumeClaim.yaml
+++ b/charts/mirrorbits/templates/persistentVolumeClaim.yaml
@@ -1,15 +1,9 @@
+{{ if $.Values.repository.persistentVolumeClaim.enabled -}}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "mirrorbits.fullname" . }}-binary
+  name: {{ $.Values.repository.name | default (printf "%s-binary" (include "mirrorbits.fullname" .))  }}
 spec:
-  accessModes:
-    - ReadWriteMany
-  #storageClassName: azurefile
-  resources:
-    requests:
-      storage: 100Gi
-  selector:
-    matchLabels:
-      data: {{ include "mirrorbits.fullname" . }}-binary
+{{ toYaml $.Values.repository.persistentVolumeClaim.spec | nindent 2 }}
+{{- end -}}

--- a/charts/mirrorbits/templates/persistentVolumeClaim.yaml
+++ b/charts/mirrorbits/templates/persistentVolumeClaim.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mirrorbits.fullname" . }}-binary
+spec:
+  accessModes:
+    - ReadWriteMany
+  #storageClassName: azurefile
+  resources:
+    requests:
+      storage: 100Gi
+  selector:
+    matchLabels:
+      data: {{ include "mirrorbits.fullname" . }}-binary

--- a/charts/mirrorbits/templates/secret.yaml
+++ b/charts/mirrorbits/templates/secret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mirrorbits.fullname" . }}-binary
+type: Opaque
+data:
+  azurestorageaccountname: {{ .Values.storageAccountName | b64enc }}
+  azurestorageaccountkey: {{ .Values.storageAccountKey | b64enc }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mirrorbits.fullname" . }}
+type: Opaque
+data:
+  mirrorbits.conf: {{ .Values.mirrorbits.conf | b64enc }}

--- a/charts/mirrorbits/templates/secret.yaml
+++ b/charts/mirrorbits/templates/secret.yaml
@@ -2,17 +2,20 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "mirrorbits.fullname" . }}-binary
-type: Opaque
-data:
-  azurestorageaccountname: {{ .Values.storageAccountName | b64enc }}
-  azurestorageaccountkey: {{ .Values.storageAccountKey | b64enc }}
-
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: {{ include "mirrorbits.fullname" . }}
 type: Opaque
 data:
   mirrorbits.conf: {{ .Values.mirrorbits.conf | b64enc }}
+
+{{ if $.Values.repository.secrets.enabled -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mirrorbits.fullname" . }}-binary
+type: Opaque
+data:
+  {{- range $key, $val := .Values.repository.secrets.data }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}
+{{- end -}}

--- a/charts/mirrorbits/templates/service.files.yaml
+++ b/charts/mirrorbits/templates/service.files.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mirrorbits.fullname" . }}-files
+  labels:
+{{ include "mirrorbits.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.files.type }}
+  ports:
+    - port: {{ .Values.service.files.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "mirrorbits.fullname" . }}-files
+    app.kubernetes.io/instance: {{ .Release.Name }}-files

--- a/charts/mirrorbits/templates/service.yaml
+++ b/charts/mirrorbits/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mirrorbits.fullname" . }}
+  labels:
+{{ include "mirrorbits.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "mirrorbits.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/mirrorbits/templates/service.yaml
+++ b/charts/mirrorbits/templates/service.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
 {{ include "mirrorbits.labels" . | indent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.service.mirrorbits.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ .Values.service.mirrorbits.port }}
       targetPort: 8080
       protocol: TCP
       name: http

--- a/charts/mirrorbits/templates/serviceaccount.yaml
+++ b/charts/mirrorbits/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "mirrorbits.serviceAccountName" . }}
+  labels:
+{{ include "mirrorbits.labels" . | indent 4 }}
+{{- end -}}

--- a/charts/mirrorbits/templates/tests/test-connection.yaml
+++ b/charts/mirrorbits/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "mirrorbits.fullname" . }}-test-connection"
+  labels:
+{{ include "mirrorbits.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "mirrorbits.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -2,12 +2,19 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount:
+  mirrorbits: 1
+  files: 1
 
 image:
-  repository: olblak/mirrorbits
-  tag: v0.5.1
-  pullPolicy: Always
+  mirrorbits:
+    repository: olblak/mirrorbits
+    tag: v0.5.1
+    pullPolicy: Always
+  files:
+    repository: nginx
+    tag: latest
+    pullPolicy: Always
 
 imagePullSecrets: []
 nameOverride: ""
@@ -32,8 +39,12 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
-  type: ClusterIP
-  port: 80
+  files:
+    type: ClusterIP
+    port: 80
+  mirrorbits:
+    type: ClusterIP
+    port: 80
 
 ingress:
   enabled: false

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -1,0 +1,68 @@
+# Default values for mirrorbits.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: olblak/mirrorbits
+  tag: v0.5.1
+  pullPolicy: Always
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -49,20 +49,43 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources:
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
 nodeSelector: {}
 
 tolerations: []
 
 affinity: {}
+
+mirrorbits:
+  # Accept the mirrorbits.conf data
+  conf: |
+    Repository: /srv/repo
+    Templates: /usr/share/mirrorbits/templates
+    RedisAddress: mirrors-redis-master:6379
+
+repository:
+  name: mirrorbits-binary
+  persistentVolumeClaim:
+    enabled: false
+    # spec hold persistentVolumeClaim spec
+    spec: {}
+
+  persistentVolume:
+    enabled: false
+    # spec hold persistentVolume spec
+    spec: {}
+  secrets:
+    enabled: false
+    # data hold secrets data used by persistentVolume
+    data: {}

--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -25,3 +25,4 @@ helmfiles:
   - path: "../helmfile.d/accountapp.yaml"
   - path: "../helmfile.d/ldap.yaml"
   - path: "../helmfile.d/uplink.yaml"
+  - path: "../helmfile.d/mirrorbits.yaml"

--- a/config/default/mirrorbits-database.yaml
+++ b/config/default/mirrorbits-database.yaml
@@ -1,0 +1,9 @@
+cluster:
+  slaveCount: 2
+metrics:
+  enabled: true
+networkPolicy:
+  enabled: false
+sentinel:
+  enabled: false
+  staticID: true

--- a/config/default/mirrorbits.yaml
+++ b/config/default/mirrorbits.yaml
@@ -1,4 +1,13 @@
-replicaCount: 3
+replicaCount: 1
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 200m
+    memory: 256Mi
+
 
 ingress:
   enabled: true
@@ -16,3 +25,37 @@ ingress:
     - secretName: mirrorbits-tls
       hosts:
         - release.mirrors.jenkins.io
+
+repository:
+  name: mirrorbits-binary
+  persistentVolumeClaim:
+    enabled: true
+    spec:
+      accessModes:
+        - ReadWriteMany
+      storageClassName: azurefile
+      resources:
+        requests:
+          storage: 100Gi
+      selector:
+        matchLabels:
+          data: mirrorbits-binary
+  persistentVolume:
+    enabled: true
+    spec:
+      capacity:
+        storage: 100Gi
+      storageClassName: azurefile
+      accessModes:
+        - ReadWriteMany
+      azureFile:
+        secretName: mirrorbits-binary
+        shareName: binary-core-packages
+        readOnly: true
+      mountOptions:
+      - dir_mode=0777
+      - file_mode=0777
+      - uid=101
+      - gid=101
+      - mfsymlinks
+      - nobrl

--- a/config/default/mirrorbits.yaml
+++ b/config/default/mirrorbits.yaml
@@ -14,7 +14,7 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     # For now deploy this service on the private ingress
-    #"kubernetes.io/ingress.class": "public-ingress"
+    "kubernetes.io/ingress.class": "public-ingress"
     "nginx.ingress.kubernetes.io/ssl-redirect": "false"
     "nginx.ingress.kubernetes.io/hsts": "false"
   hosts:

--- a/config/default/mirrorbits.yaml
+++ b/config/default/mirrorbits.yaml
@@ -1,0 +1,18 @@
+replicaCount: 3
+
+ingress:
+  enabled: true
+  annotations:
+    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+    # For now deploy this service on the private ingress
+    #"kubernetes.io/ingress.class": "public-ingress"
+    "nginx.ingress.kubernetes.io/ssl-redirect": "false"
+    "nginx.ingress.kubernetes.io/hsts": "false"
+  hosts:
+    - host: release.mirrors.jenkins.io
+      paths:
+        - /
+  tls:
+    - secretName: mirrorbits-tls
+      hosts:
+        - release.mirrors.jenkins.io

--- a/config/default/mirrorbits.yaml
+++ b/config/default/mirrorbits.yaml
@@ -1,13 +1,22 @@
-replicaCount: 3
+replicaCount:
+  mirrorbits: 3
+  files: 3
 
 resources:
-  limits:
-    cpu: 1000m
-    memory: 1024Mi
-  requests:
-    cpu: 1000m
-    memory: 1024Mi
-
+  mirrorbits:
+      limits:
+        cpu: 1000m
+        memory: 1024Mi
+      requests:
+        cpu: 1000m
+        memory: 1024Mi
+  files:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 500m
+        memory: 256Mi
 
 ingress:
   enabled: true

--- a/config/default/mirrorbits.yaml
+++ b/config/default/mirrorbits.yaml
@@ -1,4 +1,4 @@
-replicaCount: 1
+replicaCount: 3
 
 resources:
   limits:
@@ -18,13 +18,13 @@ ingress:
     "nginx.ingress.kubernetes.io/ssl-redirect": "false"
     "nginx.ingress.kubernetes.io/hsts": "false"
   hosts:
-    - host: release.mirrors.jenkins.io
+    - host: get.jenkins.io
       paths:
         - /
   tls:
     - secretName: mirrorbits-tls
       hosts:
-        - release.mirrors.jenkins.io
+        - get.jenkins.io
 
 repository:
   name: mirrorbits-binary
@@ -50,8 +50,8 @@ repository:
         - ReadWriteMany
       azureFile:
         secretName: mirrorbits-binary
-        shareName: binary-core-packages
-#        readOnly: true
+        shareName: mirrorbits
+        readOnly: true
       mountOptions:
       - dir_mode=0777
       - file_mode=0777

--- a/config/default/mirrorbits.yaml
+++ b/config/default/mirrorbits.yaml
@@ -2,11 +2,11 @@ replicaCount: 1
 
 resources:
   limits:
-    cpu: 200m
-    memory: 256Mi
+    cpu: 1000m
+    memory: 1024Mi
   requests:
-    cpu: 200m
-    memory: 256Mi
+    cpu: 1000m
+    memory: 1024Mi
 
 
 ingress:
@@ -51,11 +51,11 @@ repository:
       azureFile:
         secretName: mirrorbits-binary
         shareName: binary-core-packages
-        readOnly: true
+#        readOnly: true
       mountOptions:
       - dir_mode=0777
       - file_mode=0777
-      - uid=101
-      - gid=101
+      - uid=1000
+      - gid=1000
       - mfsymlinks
       - nobrl

--- a/helmfile.d/mirrorbits.yaml
+++ b/helmfile.d/mirrorbits.yaml
@@ -1,0 +1,24 @@
+releases:
+    - name: mirrorbits-database
+      namespace: mirrorbits
+      version: 10.3.4
+      chart: stable/redis
+      wait: true
+      timeout: 600
+      atomic: true
+      values:
+        - "../config/default/mirrorbits-database.yaml"
+      secrets:
+        - "../secrets/config/mirrorbits-database/secrets.yaml"
+
+    - name: mirrorbits
+      namespace: mirrorbits
+      chart: ../charts/mirrorbits
+      wait: true
+      timeout: 600
+      atomic: true
+      values:
+        - "../config/default/mirrorbits.yaml"
+      secrets:
+        - "../secrets/config/mirrorbits/secrets.yaml"
+


### PR DESCRIPTION
This Pull request deploys [mirrorbits](https://github.com/etix/mirrorbits) and a Redis database on Kubernetes.

In order to consider this PR as a full replacement of mirrors.jenkins.io, we still need to validate the following things
- [x] Validate that it's effectively working :) 
- [ ] Automate mirror configuration
- [ ] Make it working for Redis sentinel

Currently, this service is accessible from the VPN but empty at the moment

Update /etc/hosts with [release.mirrors.jenkins.io](https://release.mirrors.jenkins.io/?mirrorstats ) set to `10.0.2.5`

Example: https://release.mirrors.jenkins.io/debian/jenkins_2.218_all.deb?mirrorlist

or https://release.mirrors.jenkins.io/debian/jenkins_2.218_all.deb?mirrorstats
https://release.mirrors.jenkins.io/debian/jenkins_2.218_all.deb?stats