### PR TITLE
Add Github_token env variable to jenkins-wiki-exporter

### DIFF
--- a/charts/jenkins-wiki-exporter/templates/deployment.yaml
+++ b/charts/jenkins-wiki-exporter/templates/deployment.yaml
@@ -35,6 +35,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "jenkins-wiki-exporter.fullname" . }}
                   key: confluence_password
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "jenkins-wiki-exporter.fullname" . }}
+                  key: github_token
           ports:
             - name: http
               containerPort: 3000

--- a/charts/jenkins-wiki-exporter/templates/secret.yaml
+++ b/charts/jenkins-wiki-exporter/templates/secret.yaml
@@ -9,3 +9,4 @@ type: Opaque
 data:
   confluence_username: {{ .Values.confluence.username | b64enc }}
   confluence_password: {{ .Values.confluence.password | b64enc }}
+  github_token: {{ .Values.github.token | b64enc }}


### PR DESCRIPTION
This PR configure a GitHub token for the Jenkins wiki exporter as needed from this [PR](https://github.com/jenkins-infra/jenkins-wiki-exporter/pull/64) 

- [ ] Update with the new docker image tag