### PR TITLE
Revert "Lock grafana (#134)"

### DIFF
--- a/helmfile.d/grafana.lock
+++ b/helmfile.d/grafana.lock
@@ -1,7 +1,0 @@
-version: v0.99.0
-dependencies:
-- name: grafana
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 4.6.3
-digest: sha256:038427e7db9ac262dc91c9d0ab8666c17cb6a70c6f4f3796739d2bc9f15b6f89
-generated: "2020-02-25T20:50:55.143597Z"

--- a/helmfile.d/grafana.yaml
+++ b/helmfile.d/grafana.yaml
@@ -9,5 +9,3 @@ releases:
         - "../config/default/grafana.yaml"
       secrets:
         - "../secrets/config/grafana/secrets.yaml"
-bases:
-  - 00-repositories.yaml


### PR DESCRIPTION
This reverts commit 09d0e49b0db95141a16d97bc33a5cc9185f9b78c.

Grafana is not a critical service for us so I prefer to always install the latest version and fix issues when they occur than locking to  a specific version and then taking the risk to run outdated version.