### PR TITLE
Adjust Podtemplate limits

### DIFF
--- a/PodTemplates.yaml
+++ b/PodTemplates.yaml
@@ -45,11 +45,11 @@ spec:
     name: "helmfile"
     resources:
       limits:
-        memory: "256Mi"
-        cpu: "250m"
+        memory: "128Mi"
+        cpu: "400m"
       requests:
-        memory: "256Mi"
-        cpu: "250m"
+        memory: "128Mi"
+        cpu: "400m"
     securityContext:
       privileged: false
     tty: true
@@ -65,11 +65,11 @@ spec:
     name: "updatecli"
     resources:
       limits:
-        memory: "256Mi"
-        cpu: "250m"
+        memory: "64Mi"
+        cpu: "400m"
       requests:
-        memory: "256Mi"
-        cpu: "250m"
+        memory: "64Mi"
+        cpu: "400m"
     securityContext:
       privileged: false
     tty: true


### PR DESCRIPTION
The Jenkins job is failing systematically with the following error 
```
wrapper script does not seem to be touching the log file in /home/jenkins/agent/workspace/k8smgmt_master@tmp/durable-9062856f

(JENKINS-48300: if on an extremely laggy filesystem, consider -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=86400)
```
According the grafana dashboard, cpu limit is directly reached, and we still have plenty of memory so this pull request is an attempt to fix it.