### PR TITLE
Update updatecli environment variable according new name

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -34,9 +34,10 @@ pipeline {
     }
     stage('Update configuration') {
       environment {
-        UPDATECLI_SOURCE_SPEC_TOKEN                           = credentials('updatecli-github-token')
-        UPDATECLI_TARGETS_IMAGETAG_SPEC_REPOSITORY_TOKEN      = credentials('updatecli-github-token')
-        UPDATECLI_TARGETS_APPVERSION_SPEC_REPOSITORY_TOKEN    = credentials('updatecli-github-token')
+        UPDATECLI_SOURCE_SPEC_TOKEN                             = credentials('updatecli-github-token')
+        UPDATECLI_TARGETS_IMAGETAG_SCM_GITHUB_TOKEN             = credentials('updatecli-github-token')
+        UPDATECLI_TARGETS_APPVERSION_SCM_GITHUB_TOKEN           = credentials('updatecli-github-token')
+        UPDATECLI_TARGETS_JENKINSIONGINXDIGEST_SCM_GITHUB_TOKEN = credentials('updatecli-github-token')
       }
       steps {
         container('updatecli') {


### PR DESCRIPTION
I recently changed targets schema for SCM configuration and environment variables need to be updated accordingly. I'll try to work on some form of templating in order to only have to define the github token once 