### PR TITLE
Bump updatecli version

### DIFF
--- a/PodTemplates.yaml
+++ b/PodTemplates.yaml
@@ -60,7 +60,7 @@ spec:
     env:
     - name: "HOME"
       value: "/home/jenkins"
-    image: "olblak/updatecli:v0.0.5"
+    image: "olblak/updatecli:v0.0.6"
     imagePullPolicy: "Always"
     name: "updatecli"
     resources:


### PR DESCRIPTION
Version[ 0.0.6](https://github.com/olblak/updatecli/releases/tag/v0.0.6) doesn't open empty PR