### PR TITLE
Update ingress api to networking.k8s.io/v1beta1

### DIFF
--- a/charts/accountapp/templates/ingress.yaml
+++ b/charts/accountapp/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "accountapp.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/javadoc/templates/ingress.yaml
+++ b/charts/javadoc/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "javadoc.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/jenkins-wiki-exporter/templates/ingress.yaml
+++ b/charts/jenkins-wiki-exporter/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "jenkins-wiki-exporter.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/jenkinsio/templates/ingress.yaml
+++ b/charts/jenkinsio/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "jenkinsio.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/mirror/templates/ingress.yaml
+++ b/charts/mirror/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mirror.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/mirrorbits/templates/ingress.yaml
+++ b/charts/mirrorbits/templates/ingress.yaml
@@ -4,7 +4,7 @@
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 {{- end }}
 kind: Ingress
 metadata:

--- a/charts/pkg/templates/ingress.yaml
+++ b/charts/pkg/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "pkg.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/plugin-site/templates/ingress.yaml
+++ b/charts/plugin-site/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "plugin-site.fullname" . -}}
 {{- $paths := .Values.ingress.paths -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/polls/templates/admin-ingress.yaml
+++ b/charts/polls/templates/admin-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.admin_ingress.enabled -}}
 {{- $fullName := include "polls.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-admin

--- a/charts/polls/templates/ingress.yaml
+++ b/charts/polls/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "polls.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/reports/templates/ingress.yaml
+++ b/charts/reports/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "reports.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/uplink/templates/ingress.yaml
+++ b/charts/uplink/templates/ingress.yaml
@@ -4,7 +4,7 @@
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 {{- end }}
 kind: Ingress
 metadata:


### PR DESCRIPTION
Ingress resources will no longer be served from extensions/v1beta1 in v1.19. Migrate use to the networking.k8s.io/v1beta1 API, available since v1.14. Existing persisted data can be retrieved via the networking.k8s.io/v1beta1 API.

[Link](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.15.md#urgent-upgrade-notes)