### PR TITLE
Release environment must use jenkins-infra repository

### DIFF
--- a/config/default/jenkins-release.yaml
+++ b/config/default/jenkins-release.yaml
@@ -2,7 +2,7 @@ clusterAdminEnabled: false
 jenkins:
     master:
         image: jenkins/jenkins@sha256
-        imageTag: af0110d8f70d2fbaf9429c321dc4e3bc5aae12f708c655f4018e7ed4be0974f5
+        imageTag: 973a0d1dd45f0706ac720c50f14f8ea7de6a80583cc0100af76d4288a7d89714
         JCasC:
             enabled: true
             configScripts:

--- a/config/default/jenkins-release.yaml
+++ b/config/default/jenkins-release.yaml
@@ -1,6 +1,8 @@
 clusterAdminEnabled: false
 jenkins:
     master:
+        image: jenkins/jenkins@sha256
+        imageTag: af0110d8f70d2fbaf9429c321dc4e3bc5aae12f708c655f4018e7ed4be0974f5
         JCasC:
             enabled: true
             configScripts:

--- a/config/default/jenkins.yaml
+++ b/config/default/jenkins.yaml
@@ -151,7 +151,7 @@ jenkins:
                           github {
                             id('2019092401')
                             scanCredentialsId('github-access-token')
-                            repoOwner('olblak')
+                            repoOwner('jenkins-infra')
                             repository('release')
                             includes('master')
                           }

--- a/helmfile.d/jenkins-release.yaml
+++ b/helmfile.d/jenkins-release.yaml
@@ -9,7 +9,7 @@ releases:
       chart: ../charts/jenkins
       namespace: release
       values:
-        - "../config/default/jenkins.yaml"
+        - "../config/default/jenkins-release.yaml"
       secrets:
         - "../secrets/config/release/jenkins/secrets.yaml"
       set:

--- a/updateCli.d/jenkins-release.yaml
+++ b/updateCli.d/jenkins-release.yaml
@@ -2,7 +2,7 @@ source:
   kind: dockerDigest
   spec:
     image: "jenkins/jenkins"
-    tag: "lts"
+    tag: "lts-jdk11"
 targets:
   imageTag:
     name: "Jenkins Release Docker Image"

--- a/updateCli.d/jenkins-release.yaml
+++ b/updateCli.d/jenkins-release.yaml
@@ -1,0 +1,21 @@
+source:
+  kind: dockerDigest
+  spec:
+    image: "jenkins/jenkins"
+    tag: "lts"
+targets:
+  imageTag:
+    name: "Jenkins Release Docker Image"
+    kind: yaml
+    spec:
+      file: "config/default/jenkins-release.yaml"
+      key: "jenkins.master.imageTag"
+    scm:
+      github:
+        user: "updatecli"
+        email: "updatecli@olblak.com"
+        owner: "jenkins-infra"
+        repository: "charts"
+        token: ""
+        username: "olblak"
+        branch: "master"


### PR DESCRIPTION
* Switch release.ci.jenkins.io to lts version and automate its upgrade when a new docker image is available based on digest
* Rename jenkins.yaml configuration file to jenkins-release.yaml to be more explicit on the content
* Fix release.ci.jenkins.io packaging job to use jenkins-infra/release instead of olblak/release