### PR TITLE
Add persistentVolumeClaim matchlabel for jenkins release env

### DIFF
--- a/charts/env-jenkins-release/templates/core-packages.yaml
+++ b/charts/env-jenkins-release/templates/core-packages.yaml
@@ -41,6 +41,9 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: azurefile
+  selector:
+    matchLabels:
+      name: "binary-core-packages"
   resources:
     requests:
       storage: 100Gi
@@ -77,6 +80,9 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: azurefile
+  selector:
+    matchLabels:
+      name: "website-core-packages"
   resources:
     requests:
       storage: 100Gi


### PR DESCRIPTION
Current those persistentVolumeClaim are not bind to the correct PV