### PR TITLE
Remove pvc selector for env-jenkins-release

### DIFF
--- a/charts/env-jenkins-release/templates/core-packages.yaml
+++ b/charts/env-jenkins-release/templates/core-packages.yaml
@@ -41,9 +41,6 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: azurefile
-  selector:
-    matchLabels:
-      name: "binary-core-packages"
   resources:
     requests:
       storage: 100Gi
@@ -80,9 +77,6 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: azurefile
-  selector:
-    matchLabels:
-      name: "website-core-packages"
   resources:
     requests:
       storage: 100Gi


### PR DESCRIPTION
I rollback this change as using selector implies being dynamic storage which is not our need.
For some reason, now the pvc matches the correct pv 

Ps: I am manually made the change as manipulate pvc implies deleting them