### PR TITLE
Redirect jenkins.io to www.jenkins.io

### DIFF
--- a/charts/jenkinsio/templates/nginx-configmap.yaml
+++ b/charts/jenkinsio/templates/nginx-configmap.yaml
@@ -15,8 +15,8 @@ data:
       server_name  localhost;
   
       {{- if .Values.forceJenkinsIoHost -}}
-      if ( $host != 'jenkins.io') {
-        return 301 $scheme://jenkins.io$request_uri;
+      if ( $host != 'www.jenkins.io') {
+        return 301 $scheme://www.jenkins.io$request_uri;
       }
       {{- end }}
   
@@ -26,7 +26,7 @@ data:
           index  index.html index.htm;
           # Language setting
           if ($lang) {
-            rewrite ^/$ https://jenkins.io/$lang$1;
+            rewrite ^/$ https://www.jenkins.io/$lang$1;
           }   
       }
 
@@ -101,7 +101,7 @@ data:
       # baked in jenkins.war 1.587 / 1.580.1
       rewrite ^/security-144$          https://wiki.jenkins-ci.org/display/JENKINS/Slave+To+Master+Access+Control permanent;
       # baked in 1.600 easter egg
-      rewrite ^/100k$                  https://jenkins.io/content/jenkins-celebration-day-february-26 permanent;
+      rewrite ^/100k$                  https://www.jenkins.io/content/jenkins-celebration-day-february-26 permanent;
       rewrite ^/jep/([0-9]+) https://github.com/jenkinsci/jep/blob/master/jep/$1/README.adoc permanent;
       rewrite ^/iep/([0-9]+) https://github.com/jenkins-infra/iep/blob/master/iep/$1/README.adoc permanent;
     }

--- a/charts/jenkinsio/templates/zh-configmap.yaml
+++ b/charts/jenkinsio/templates/zh-configmap.yaml
@@ -11,8 +11,8 @@ data:
       server_name  localhost;
   
     {{- if .Values.forceJenkinsIoHost -}}
-      if ( $host != 'jenkins.io') {
-        return 301 $scheme://jenkins.io/zh/$request_uri;
+      if ( $host != 'www.jenkins.io') {
+        return 301 $scheme://www.jenkins.io/zh/$request_uri;
       }
     {{- end }}
   

--- a/config/default/jenkinsio.yaml
+++ b/config/default/jenkinsio.yaml
@@ -50,6 +50,7 @@ ingress:
     - secretName: jenkinsio-tls
       hosts:
         - jenkins.io
+        - www.jenkins.io
         - jenkins-ci.org
         - www.jenkins-ci.org
 

--- a/config/default/jenkinsio.yaml
+++ b/config/default/jenkinsio.yaml
@@ -76,4 +76,4 @@ zhHtmlVolume:
     shareName: zhjenkinsio
     readOnly: true
 
-forceJenkinsIoHost: true
+forceJenkinsIoHost: false

--- a/config/default/jenkinsio.yaml
+++ b/config/default/jenkinsio.yaml
@@ -6,7 +6,7 @@ ingress:
     "nginx.ingress.kubernetes.io/ssl-redirect": "false"
     "nginx.ingress.kubernetes.io/configuration-snippet": |
       if ( $scheme = "http" ) {
-        rewrite ^/((?!patron|maven-site|jenkins.jnlp).+)$ https://jenkins.io/$1 permanent;
+        rewrite ^/((?!patron|maven-site|jenkins.jnlp).+)$ https://www.jenkins.io/$1 permanent;
         rewrite ^/$ https://$host permanent;
       }
       if ( $scheme = "https" ) {
@@ -15,6 +15,14 @@ ingress:
 
   hosts:
     - host: jenkins.io
+      paths:
+        - path: /
+          serviceName: jenkinsio
+          servicePort: 80
+        - path: /zh/
+          serviceName: jenkinsio-zh
+          servicePort: 80
+    - host: www.jenkins.io
       paths:
         - path: /
           serviceName: jenkinsio


### PR DESCRIPTION
I propose to switch jenkins.io website from apex domain to www.jenkins.io.
The main motivation is to be able to proxy www.jenkins.io using a CNAME record from www to dualstack.d.sni.global.fastly.net. (which also support IPV6)
https://docs.fastly.com/en/guides/using-fastly-with-apex-domains