### PR TITLE
Fix release core persistentVolume

### DIFF
--- a/charts/env-jenkins-release/templates/core-packages.yaml
+++ b/charts/env-jenkins-release/templates/core-packages.yaml
@@ -14,12 +14,13 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: binary-core-packages
+  labels:
+    data: binary
 spec:
   capacity:
     storage: 100Gi
   accessModes:
     - ReadWriteMany
-  storageClassName: azurefile
   azureFile:
     secretName: core-packages
     shareName: {{ .Values.corePackages.shareName }}
@@ -38,24 +39,28 @@ kind: PersistentVolumeClaim
 metadata:
   name: binary-core-packages
 spec:
+  storageClassName: ""
   accessModes:
     - ReadWriteMany
-  storageClassName: azurefile
   resources:
     requests:
       storage: 100Gi
+  selector:
+    matchLabels:
+      data: "binary"
 
 ---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: website-core-packages
+  labels:
+    data: pkgsite
 spec:
   capacity:
     storage: 100Gi
   accessModes:
     - ReadWriteMany
-  storageClassName: azurefile
   azureFile:
     secretName: core-packages
     shareName: {{ .Values.corePackages.websiteShareName }}
@@ -74,10 +79,13 @@ kind: PersistentVolumeClaim
 metadata:
   name: website-core-packages
 spec:
+  storageClassName: ""
   accessModes:
     - ReadWriteMany
-  storageClassName: azurefile
   resources:
     requests:
       storage: 100Gi
+  selector:
+    matchLabels:
+      data: "pkgsite"
 {{ end }}


### PR DESCRIPTION
Those two volumes are used to upload core packages on an azure file storage, until now the pvc used the wrong volume, instead of using the one specified here, it was using dynamically created volumes.

This pull request aligns with local changes