### PR TITLE
Switch ldap certificate to letsencrypt

### DIFF
--- a/charts/ldap/templates/certificate.yaml
+++ b/charts/ldap/templates/certificate.yaml
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: ldap-tls
+spec:
+  secretName: ldap-tls
+  dnsNames:
+  {{- range .Values.dnsNames }}
+  - {{ . }}
+  {{- end }}
+  issuerRef:
+    name: letsencrypt-prod
+    # We can reference ClusterIssuers by changing the kind here.
+    # The default value is Issuer (i.e. a locally namespaced Issuer)
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/charts/ldap/templates/secret.yaml
+++ b/charts/ldap/templates/secret.yaml
@@ -10,6 +10,3 @@ data:
   azurestorageaccountname: {{ .Values.ldap.storage.accountname | b64enc }}
   azurestorageaccountkey: {{ .Values.ldap.storage.accountkey | b64enc }}
   ldap.admin.password: {{ .Values.ldap.admin.password | b64enc }}
-  cacert.pem: {{ .Values.ldap.ssl.ca.value | b64enc }}
-  cert.pem: {{ .Values.ldap.ssl.crt.value | b64enc }}
-  privkey.key: {{ .Values.ldap.ssl.key.value | b64enc }}

--- a/charts/ldap/templates/statefulset.yaml
+++ b/charts/ldap/templates/statefulset.yaml
@@ -124,11 +124,11 @@ spec:
             claimName: {{ include "ldap.fullname" . }}-data
         - name: tls
           secret:
-            secretName: {{ include "ldap.fullname" . }}
+            secretName: ldap-tls
             items:
-              - key: cacert.pem
+              - key: ca.crt
                 path: {{ .Values.ldap.ssl.ca.filename }}
-              - key: cert.pem
+              - key: tls.crt
                 path: {{ .Values.ldap.ssl.crt.filename }}
-              - key: privkey.key
+              - key: tls.key
                 path: {{ .Values.ldap.ssl.key.filename }}

--- a/charts/ldap/values.yaml
+++ b/charts/ldap/values.yaml
@@ -75,3 +75,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+dnsNames:
+  - ldap.jenkins.io


### PR DESCRIPTION
This pull request has already been tested and deployed, I took two shortcuts here
* The ldap container won't detect a certificate change so this is something that need to implemented
* The secret generated by the certificate doesn't add any value to ca.crt, so I did it manually