### PR TITLE
Update updatecli configuration to v0.0.7

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -32,16 +32,23 @@ pipeline {
         }
       }
     }
-    stage('Update configuration') {
+    stage('Check Configuration Update') {
       environment {
-        UPDATECLI_SOURCE_SPEC_TOKEN                             = credentials('updatecli-github-token')
-        UPDATECLI_TARGETS_IMAGETAG_SCM_GITHUB_TOKEN             = credentials('updatecli-github-token')
-        UPDATECLI_TARGETS_APPVERSION_SCM_GITHUB_TOKEN           = credentials('updatecli-github-token')
-        UPDATECLI_TARGETS_JENKINSIONGINXDIGEST_SCM_GITHUB_TOKEN = credentials('updatecli-github-token')
+        UPDATECLI_GITHUB_TOKEN  = credentials('updatecli-github-token')
       }
       steps {
         container('updatecli') {
-          sh 'updatecli --config ./updateCli.d'
+          sh 'updatecli diff --config ./updatecli/updateCli.d --values ./updatecli/values.yaml'
+        }
+      }
+    }
+    stage('Apply Configuration Update') {
+      environment {
+        UPDATECLI_GITHUB_TOKEN  = credentials('updatecli-github-token')
+      }
+      steps {
+        container('updatecli') {
+          sh 'updatecli apply --config ./updatecli/updateCli.d --values ./updatecli/values.yaml'
         }
       }
     }

--- a/PodTemplates.yaml
+++ b/PodTemplates.yaml
@@ -60,7 +60,7 @@ spec:
     env:
     - name: "HOME"
       value: "/home/jenkins"
-    image: "olblak/updatecli:v0.0.6"
+    image: "olblak/updatecli:v0.0.7"
     imagePullPolicy: "Always"
     name: "updatecli"
     resources:

--- a/updateCli/updateCli.d/jenkins-lts-jdk11.tpl
+++ b/updateCli/updateCli.d/jenkins-lts-jdk11.tpl
@@ -12,10 +12,10 @@ targets:
       key: "jenkins.master.imageTag"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
         owner: "jenkins-infra"
         repository: "charts"
-        token: ""
-        username: "olblak"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
         branch: "master"

--- a/updateCli/updateCli.d/jenkins-weekly-jdk11.tpl
+++ b/updateCli/updateCli.d/jenkins-weekly-jdk11.tpl
@@ -22,10 +22,10 @@ targets:
       key: "jenkins.master.imageTag"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
         owner: "jenkins-infra"
         repository: "charts"
-        token: ""
-        username: "olblak"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
         branch: "master"

--- a/updateCli/updateCli.d/jenkins-wiki-exporter.tpl
+++ b/updateCli/updateCli.d/jenkins-wiki-exporter.tpl
@@ -3,7 +3,7 @@ source:
   spec:
     owner: "jenkins-infra"
     repository: "jenkins-wiki-exporter"
-    token: ""
+    token: "{{ requiredEnv "GITHUB_TOKEN" }}"
     username: "olblak"
     version: "latest"
 conditions:
@@ -21,12 +21,12 @@ targets:
       key: image.tag
     scm:
       github:
-        user: "update-bot"
-        email: "update-bot@olblak.com"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
         owner: "jenkins-infra"
         repository: "charts"
-        token: ""
-        username: "olblak"
+        token: "{{ requiredEnv "GITHUB_TOKEN" }}"
+        username: "{{ .github.username }}"
         branch: "master"
   appVersion:
     name: "Chart appVersion"
@@ -36,10 +36,10 @@ targets:
       key: appVersion
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
         owner: "jenkins-infra"
         repository: "charts"
-        token: ""
-        username: "olblak"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
         branch: "master"

--- a/updateCli/updateCli.d/nginx.tpl
+++ b/updateCli/updateCli.d/nginx.tpl
@@ -4,7 +4,7 @@ source:
     image: "nginx"
     tag: "1.17"
 targets:
-  jenkinsioNginxDigest:
+  nginx:
     name: "Jenkins.io nginx"
     kind: yaml
     spec:
@@ -12,10 +12,10 @@ targets:
       key: image.tag
     scm:
       github:
-        user: "update-bot"
-        email: "update-bot@olblak.com"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
         owner: "jenkins-infra"
         repository: "charts"
-        token: ""
-        username: "olblak"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
         branch: "master"

--- a/updateCli/updateCli.d/pluginsite.tpl
+++ b/updateCli/updateCli.d/pluginsite.tpl
@@ -4,7 +4,7 @@ source:
   spec:
     owner: "jenkins-infra"
     repository: "plugin-site-api"
-    token: ""
+    token: "{{ requiredEnv .github.token }}"
     username: "olblak"
     version: "latest"
 conditions:
@@ -22,11 +22,11 @@ targets:
       key: "backend.image.tag"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
         owner: "jenkins-infra"
         repository: "charts"
-        token: ""
+        token: "{{ requiredEnv .github.token }}"
         username: "olblak"
         branch: "master"
   appVersion:
@@ -37,10 +37,10 @@ targets:
       key: appVersion
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
         owner: "jenkins-infra"
         repository: "charts"
-        token: ""
+        token: "{{ requiredEnv .github.token }}"
         username: "olblak"
         branch: "master"

--- a/updateCli/values.yaml
+++ b/updateCli/values.yaml
@@ -2,4 +2,4 @@ github:
   user: "updatebot"
   email: "updatebot@olblak.com"
   username: "olblak"
-  token: "GITHUB_TOKEN" 
+  token: "UPDATECLI_GITHUB_TOKEN" 

--- a/updateCli/values.yaml
+++ b/updateCli/values.yaml
@@ -1,0 +1,5 @@
+github:
+  user: "updatebot"
+  email: "updatebot@olblak.com"
+  username: "olblak"
+  token: "GITHUB_TOKEN" 


### PR DESCRIPTION
Update configuration to work with release [v0.0.7](https://github.com/olblak/updatecli/releases/tag/v0.0.7), we can now use go template instead of yaml which simplifies the management of multiple configurations,  and it also support three new commands 
```
updatecli diff --config .. --values
updatecli show --config ... --values ...
updatecli apply --config ... --values ...
```

