### PR TITLE
Fix ldap cron image tag

### DIFF
--- a/charts/ldap/templates/statefulset.yaml
+++ b/charts/ldap/templates/statefulset.yaml
@@ -53,8 +53,8 @@ spec:
               value: {{ .Values.ldap.ssl.crt.filename }}
             - name: OPENLDAP_SSL_KEY
               value: {{ .Values.ldap.ssl.key.filename }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.image.slapd.repository }}:{{ .Values.image.slapd.tag }}"
+          imagePullPolicy: {{ .Values.image.slapd.pullPolicy }}
           ports:
             - name: ldaps
               containerPort: 636
@@ -94,8 +94,8 @@ spec:
               value: {{ .Values.ldap.ssl.crt.filename }}
             - name: OPENLDAP_SSL_KEY
               value: {{ .Values.ldap.ssl.key.filename }}
-          image: "{{ .Values.image.repository }}:cron-{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.image.crond.repository }}:{{ .Values.image.crond.tag }}"
+          imagePullPolicy: {{ .Values.image.crond.pullPolicy }}
           volumeMounts:
             - name: backup
               mountPath: {{ .Values.ldap.backup.path }}

--- a/charts/ldap/values.yaml
+++ b/charts/ldap/values.yaml
@@ -5,9 +5,14 @@
 replicaCount: 1
 
 image:
-  repository: jenkinsciinfra/ldap@sha256
-  tag: 6a272bb54780919010eebee33fc2cafb8406ca42af0209c7b6b8ed2f1e38a3b6
-  pullPolicy: IfNotPresent
+  slapd:
+    repository: jenkinsciinfra/ldap@sha256
+    tag: 6a272bb54780919010eebee33fc2cafb8406ca42af0209c7b6b8ed2f1e38a3b6
+    pullPolicy: IfNotPresent
+  crond:
+    repository: jenkinsciinfra/ldap@sha256
+    tag: d942a1e14f7aeb07da0f6428c84b4d4bcdfca22f0922e3ba21bb702d29fcae48
+    pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 nameOverride: ""

--- a/updateCli/updateCli.d/ldap-crond.tpl
+++ b/updateCli/updateCli.d/ldap-crond.tpl
@@ -2,14 +2,14 @@ source:
   kind: dockerDigest
   spec:
     image: "jenkinsciinfra/ldap"
-    tag: "latest"
+    tag: "cron-latest"
 targets:
   imageTag:
     name: "Ldap Docker Image"
     kind: yaml
     spec:
       file: "charts/ldap/values.yaml"
-      key: "image.tag"
+      key: "image.crond.tag"
     scm:
       github:
         user: "{{ .github.user }}"

--- a/updateCli/updateCli.d/ldap-slapd.tpl
+++ b/updateCli/updateCli.d/ldap-slapd.tpl
@@ -1,0 +1,21 @@
+source:
+  kind: dockerDigest
+  spec:
+    image: "jenkinsciinfra/ldap"
+    tag: "latest"
+targets:
+  imageTag:
+    name: "Ldap Docker Image"
+    kind: yaml
+    spec:
+      file: "charts/ldap/values.yaml"
+      key: "image.slapd.tag"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "jenkins-infra"
+        repository: "charts"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "master"


### PR DESCRIPTION
1. Fix docker image tag used for the cron daemon
2. Automate both slapd and crond docker image tag by using digest