### PR TITLE
Add Vary header Accept-Language to nginx to allow separate cache per language

### DIFF
--- a/charts/jenkinsio/templates/nginx-configmap.yaml
+++ b/charts/jenkinsio/templates/nginx-configmap.yaml
@@ -24,6 +24,7 @@ data:
 
       location / {
           index  index.html index.htm;
+          add_header Vary "Accept-Language";
           # Language setting
           if ($lang) {
             rewrite ^/$ https://www.jenkins.io/$lang$1;


### PR DESCRIPTION
This change is discussed in the jenkins.io issue in https://github.com/jenkins-infra/jenkins.io/issues/3336 

Added the Vary header `Vary: Accept-Language` to nginx so that Fastly can keep separate cache for the languages.

Works in conjunction with the changes done by @olblak in Fastly (https://github.com/jenkins-infra/jenkins.io/issues/3336#issuecomment-635889745)