### PR TITLE
Deploy keycloak

### DIFF
--- a/charts/keycloak/.helmignore
+++ b/charts/keycloak/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: keycloak
+description: Non Admin keycloak interface
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/charts/keycloak/templates/NOTES.txt
+++ b/charts/keycloak/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "keycloak.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "keycloak.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "keycloak.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "keycloak.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "keycloak.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "keycloak.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "keycloak.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "keycloak.labels" -}}
+helm.sh/chart: {{ include "keycloak.chart" . }}
+{{ include "keycloak.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "keycloak.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "keycloak.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "keycloak.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "keycloak.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "keycloak.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    nginx.ingress.kubernetes.io/app-root: /auth/realms/jenkins/account
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: keycloak-http
+              servicePort: 80
+          - path: /auth/admin/
+            backend:
+              serviceName: {{ $fullName }}-404
+              servicePort: 80
+    {{- end }}
+  {{- end }}

--- a/charts/keycloak/templates/service.yaml
+++ b/charts/keycloak/templates/service.yaml
@@ -1,0 +1,12 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ include "keycloak.fullname" . }}-404
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  type: ExternalName
+  externalName: public-nginx-ingress-default-backend.kube-system.svc.cluster.local
+  ports:
+    - port: 80

--- a/charts/keycloak/templates/tests/test-connection.yaml
+++ b/charts/keycloak/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "keycloak.fullname" . }}-test-connection"
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "keycloak.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -1,0 +1,20 @@
+# Default values for keycloak.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/config/default/keycloak-public.yaml
+++ b/config/default/keycloak-public.yaml
@@ -1,0 +1,12 @@
+ingress:
+  enabled: true
+  annotations:
+    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+    "kubernetes.io/ingress.class": "public-ingress"
+  labels:
+  tls:
+    - hosts:
+        - beta.accounts.jenkins.io
+      secretName: keycloak-public-cert
+  hosts:
+    - host: beta.accounts.jenkins.io

--- a/config/default/keycloak.yaml
+++ b/config/default/keycloak.yaml
@@ -16,7 +16,7 @@ keycloak:
       - admin.accounts.jenkins.io
   extraInitContainers: |
     - name: theme-provider
-      image: timja/jenkins-keycloak-theme:0.1
+      image: jenkinsciinfra/keycloak-theme:0.0.1
       imagePullPolicy: IfNotPresent
       command:
         - sh

--- a/config/default/keycloak.yaml
+++ b/config/default/keycloak.yaml
@@ -13,6 +13,28 @@ keycloak:
     path: "/"
     hosts:
       - admin.accounts.jenkins.io
+  extraInitContainers: |
+    - name: theme-provider
+      image: timja/jenkins-keycloak-theme:0.1
+      imagePullPolicy: IfNotPresent
+      command:
+        - sh
+      args:
+        - -c
+        - |
+          echo "Copying theme..."
+          cp -R /jenkins/* /theme
+      volumeMounts:
+        - name: theme
+          mountPath: /theme
+
+  extraVolumeMounts: |
+    - name: theme
+      mountPath: /opt/jboss/keycloak/themes/jenkins
+
+  extraVolumes: |
+    - name: theme
+      emptyDir: {}
   resources:
     limits:
       cpu: 1000m

--- a/config/default/keycloak.yaml
+++ b/config/default/keycloak.yaml
@@ -1,4 +1,5 @@
 keycloak:
+  replicas: 2
   ingress:
     enabled: true
     annotations: 

--- a/config/default/keycloak.yaml
+++ b/config/default/keycloak.yaml
@@ -1,0 +1,22 @@
+keycloak:
+  ingress:
+    enabled: true
+    annotations: 
+      "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+      "kubernetes.io/ingress.class": "nginx"
+      "nginx.ingress.kubernetes.io/proxy-body-size": "500m"
+    labels:
+    tls:
+      - hosts:
+          - admin.accounts.jenkins.io
+        secretName: keycloak-cert
+    path: "/"
+    hosts:
+      - admin.accounts.jenkins.io
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 500m
+      memory: 512Mi

--- a/config/default/keycloak.yaml
+++ b/config/default/keycloak.yaml
@@ -15,8 +15,8 @@ keycloak:
       - admin.accounts.jenkins.io
   resources:
     limits:
-      cpu: 500m
-      memory: 512Mi
+      cpu: 1000m
+      memory: 2048Mi
     requests:
-      cpu: 500m
-      memory: 512Mi
+      cpu: 1000m
+      memory: 2048Mi

--- a/helmfile.d/keycloak.yaml
+++ b/helmfile.d/keycloak.yaml
@@ -1,0 +1,20 @@
+repositories:
+  - name: codecentric
+    url: https://codecentric.github.io/helm-charts
+releases:
+    - name: keycloak
+      namespace: keycloak
+      chart: codecentric/keycloak
+      version: 8.2.2
+      wait: true
+      timeout: 300
+      atomic: true
+      values:
+        - "../config/default/keycloak.yaml"
+      secrets:
+        - "../secrets/config/keycloak/secrets.yaml"
+
+# User
+# https://admin.accounts.jenkins.io/auth/realms/jenkins/account
+# Admin
+# https://admin.accounts.jenkins.io/auth/admin

--- a/helmfile.d/keycloak.yaml
+++ b/helmfile.d/keycloak.yaml
@@ -2,6 +2,8 @@ repositories:
   - name: codecentric
     url: https://codecentric.github.io/helm-charts
 releases:
+    # Admin
+    # https://admin.accounts.jenkins.io/auth/admin
     - name: keycloak
       namespace: keycloak
       chart: codecentric/keycloak
@@ -14,7 +16,13 @@ releases:
       secrets:
         - "../secrets/config/keycloak/secrets.yaml"
 
-# User
-# https://admin.accounts.jenkins.io/auth/realms/jenkins/account
-# Admin
-# https://admin.accounts.jenkins.io/auth/admin
+    # User
+    # https://admin.accounts.jenkins.io/auth/realms/jenkins/account
+    - name: keycloak-public
+      namespace: keycloak
+      chart: ../charts/keycloak
+      wait: true
+      timeout: 150
+      atomic: true
+      values:
+        - "../config/default/keycloak-public.yaml"


### PR DESCRIPTION
This pull request is an expirement to use something more robust than accounts.jenkins.io

It has already been deployed manually  && configured on the cluster and is available for [user](https://admin.accounts.jenkins.io/auth/realms/jenkins/account), or [administrator](https://admin.accounts.jenkins.io/auth/admin)

User are allowed to use existing ldap account (same than accounts.jenkins.io) or to delete/register new one.

If this experimentation is a success, I propose to redirect accounts.jenkins.io to https://admin.accounts.jenkins.io/auth/realms/jenkins/account[

[Screenshot](https://usercontent.irccloud-cdn.com/file/LsYpQZF2/image.png)