### PR TITLE
[INFRA-2651] Replace Accountapp by Keycloak

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -19,7 +19,7 @@ helmfiles:
   - path: "../helmfile.d/reports.yaml"
   - path: "../helmfile.d/jenkinsio.yaml"
   - path: "../helmfile.d/javadoc.yaml"
-  - path: "../helmfile.d/accountapp.yaml"
+  - path: "../helmfile.d/keycloak.yaml"
   - path: "../helmfile.d/ldap.yaml"
   - path: "../helmfile.d/uplink.yaml"
   - path: "../helmfile.d/mirrorbits.yaml"

--- a/config/default/keycloak-public.yaml
+++ b/config/default/keycloak-public.yaml
@@ -6,7 +6,7 @@ ingress:
   labels:
   tls:
     - hosts:
-        - beta.accounts.jenkins.io
+        - accounts.jenkins.io
       secretName: keycloak-public-cert
   hosts:
-    - host: beta.accounts.jenkins.io
+    - host: accounts.jenkins.io


### PR DESCRIPTION
<!--
Thank you for contributing to jenkins-infra/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkins-infra/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm-www/tree/master/content/en/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/jenkins-infra/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Jenkins job
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This pull request replaces the old account app with keycloak. Keycloak will also use url accounts.jenkins.io instead of beta.accounts.jenkins.io. Once approved I'll manually remove the old accountapp and apply changes from this pull request then everything will get back to normal

#### Which issue this PR fixes

  - fixes # [INFRA-2651](https://issues.jenkins-ci.org/browse/INFRA-2651)

