### PR TITLE
Remove deprecated helm option - recreatePod

### DIFF
--- a/helmfile.d/dex.yaml
+++ b/helmfile.d/dex.yaml
@@ -7,7 +7,6 @@ releases:
       namespace: dex
       wait: true
       timeout: 300
-      recreatePods: true
       force: true
       atomic: true
       values:


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

```
Flag --recreate-pods has been deprecated, functionality will no longer be updated. Consult the documentation for other methods to recreate pods
```