### PR TITLE
Update windows inbound agent used by release environment

### DIFF
--- a/config/default/jenkins-release.yaml
+++ b/config/default/jenkins-release.yaml
@@ -151,12 +151,11 @@ jenkins:
                       nodeSelector: "kubernetes.io/os=windows"
                       containers:
                         - name: jnlp
-                          image: "jenkins4eval/jnlp-agent:latest-windows"
+                          image: "jenkins/inbound-agent:windowsservercore-1809"
                           resourceLimitCpu: "500m"
-                          resourceLimitMemory: "512Mi"
+                          resourceLimitMemory: "1024Mi"
                           resourceRequestCpu: "500m"
-                          resourceRequestMemory: "512Mi"
-                          args: "^${computer.jnlpmac} ^${computer.name}"
+                          resourceRequestMemory: "1024Mi"
                           alwaysPullImage: true
                       yaml: |-
                         spec:


### PR DESCRIPTION
Update default windows inbound agent from "jenkins4eval/jnlp-agent:latest-windows" to "jenkins/inbound-agent:windowsservercore-1809"