### PR TITLE
[INFRA-2660] Allow triggering release job using different branches

### DIFF
--- a/config/default/jenkins-release.yaml
+++ b/config/default/jenkins-release.yaml
@@ -202,6 +202,7 @@ jenkins:
                 folder('core/weekly') {
                   displayName('Weekly')
                   description('Folder for weekly releases')
+                  includes('master')
                 }
 
             - script: >

--- a/config/default/jenkins-release.yaml
+++ b/config/default/jenkins-release.yaml
@@ -226,7 +226,6 @@ jenkins:
                       scanCredentialsId('github-access-token')
                       repoOwner('jenkins-infra')
                       repository('release')
-                      includes('master')
                     }
                   }
                   factory {
@@ -245,7 +244,6 @@ jenkins:
                       scanCredentialsId('github-access-token')
                       repoOwner('jenkins-infra')
                       repository('release')
-                      includes('master')
                     }
                   }
                   factory {
@@ -284,7 +282,6 @@ jenkins:
                       scanCredentialsId('github-access-token')
                       repoOwner('jenkins-infra')
                       repository('release')
-                      includes('master')
                     }
                   }
                   factory {
@@ -303,7 +300,6 @@ jenkins:
                       scanCredentialsId('github-access-token')
                       repoOwner('jenkins-infra')
                       repository('release')
-                      includes('master')
                     }
                   }
                   factory {

--- a/config/default/jenkins-release.yaml
+++ b/config/default/jenkins-release.yaml
@@ -202,7 +202,6 @@ jenkins:
                 folder('core/weekly') {
                   displayName('Weekly')
                   description('Folder for weekly releases')
-                  includes('master')
                 }
 
             - script: >


### PR DESCRIPTION
[INFRA-2660](https://issues.jenkins-ci.org/browse/INFRA-2660)

This pull request will update release.ci.jenkins.io configuration to allow release job to use different branch than master for:
* Stable release
* Security release
* Generic core release
* Generic core packaging

This pull request is required for this [one](https://github.com/jenkins-infra/release/pull/81) to work
