### PR TITLE
[loki] Increase loki install timeout

### DIFF
--- a/helmfile.d/loki.yaml
+++ b/helmfile.d/loki.yaml
@@ -7,7 +7,7 @@ releases:
   chart: loki/loki
   version: 0.30.1
   wait: true
-  timeout: 100
+  timeout: 300
   force: true
   atomic: true
   values:


### PR DESCRIPTION
It needed re-installing probably due to a chart version update.

And it wouldn't install in the 100 second timeout that was set due to slow volume attach.

It took about 200 seconds on my machine, but bumped it to 300 to be safe