### PR TITLE
Improve updatecli configuration

### DIFF
--- a/updateCli/updateCli.d/charts/codecentric-keycloak.tpl
+++ b/updateCli/updateCli.d/charts/codecentric-keycloak.tpl
@@ -3,14 +3,29 @@ source:
   spec:
     url: https://codecentric.github.io/helm-charts
     name: keycloak
-
 conditions:
   exist:
     name: "Keycloack helm chart available on Registry"
     kind: helmChart
     spec:
       url: https://codecentric.github.io/helm-charts
-      name: keycloack
+      name: keycloak
+  helmfileRelease:
+    name: "codecentric/keycloak Helm Chart"
+    kind: yaml
+    spec:
+      file: "helmfile.d/keycloak.yaml"
+      key: "releases[0].name"
+      value: "keycloak"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "jenkins-infra"
+        repository: "charts"
+        token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
+        username: "{{ .github.username }}"
+        branch: "master"
 targets:
   chartVersion:
     name: "codecentric/keycloak Helm Chart"
@@ -20,10 +35,10 @@ targets:
       key: "releases[0].version"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
         owner: "jenkins-infra"
         repository: "charts"
         token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-        username: "olblak"
+        username: "{{ .github.username }}"
         branch: "master"

--- a/updateCli/updateCli.d/charts/dex.tpl
+++ b/updateCli/updateCli.d/charts/dex.tpl
@@ -11,6 +11,22 @@ conditions:
     spec:
       url: https://kubernetes-charts.storage.googleapis.com
       name: dex
+  helmfileRelease:
+    name: "stable/dex Helm Chart"
+    kind: yaml
+    spec:
+      file: "helmfile.d/dex.yaml"
+      key: "releases[0].name"
+      value: "private-dex"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
 
 targets:
   chartVersion:
@@ -21,10 +37,10 @@ targets:
       key: "releases[0].version"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
-        owner: "jenkins-infra"
-        repository: "charts"
-        token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-        username: "olblak"
-        branch: "master"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updateCli/updateCli.d/charts/grafana-loki.tpl
+++ b/updateCli/updateCli.d/charts/grafana-loki.tpl
@@ -11,6 +11,22 @@ conditions:
     spec:
       url: https://grafana.github.io/loki/charts
       name: loki
+  helmfileRelease:
+    name: "grafana/loki Helm Chart"
+    kind: yaml
+    spec:
+      file: "helmfile.d/loki.yaml"
+      key: "releases[0].name"
+      value: "loki"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
 
 targets:
   chartVersion:
@@ -21,10 +37,10 @@ targets:
       key: "releases[0].version"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
-        owner: "jenkins-infra"
-        repository: "charts"
-        token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-        username: "olblak"
-        branch: "master"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updateCli/updateCli.d/charts/grafana-promtail.tpl
+++ b/updateCli/updateCli.d/charts/grafana-promtail.tpl
@@ -11,6 +11,22 @@ conditions:
     spec:
       url: https://grafana.github.io/loki/charts
       name: promtail
+  helmfileRelease:
+    name: "grafana/promtail Helm Chart"
+    kind: yaml
+    spec:
+      file: "helmfile.d/promtail.yaml"
+      key: "releases[0].name"
+      value: "promtail"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
 
 targets:
   chartVersion:
@@ -21,10 +37,10 @@ targets:
       key: "releases[0].version"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
-        owner: "jenkins-infra"
-        repository: "charts"
-        token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-        username: "olblak"
-        branch: "master"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updateCli/updateCli.d/charts/jetstack-certmanager.tpl
+++ b/updateCli/updateCli.d/charts/jetstack-certmanager.tpl
@@ -11,7 +11,22 @@ conditions:
     spec:
       url: https://charts.jetstack.io
       name: cert-manager
-
+  helmfileRelease:
+    name: "jetstack/cert-manager Helm Chart"
+    kind: yaml
+    spec:
+      file: "helmfile.d/cert-manager.yaml"
+      key: "releases[0].name"
+      value: "cert-manager"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
 targets:
   chartVersion:
     name: "jetstack/cert-manager Helm Chart"
@@ -21,10 +36,10 @@ targets:
       key: "releases[0].version"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
-        owner: "jenkins-infra"
-        repository: "charts"
-        token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-        username: "olblak"
-        branch: "master"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updateCli/updateCli.d/charts/prometheus.tpl
+++ b/updateCli/updateCli.d/charts/prometheus.tpl
@@ -11,6 +11,22 @@ conditions:
     spec:
       url: https://kubernetes-charts.storage.googleapis.com
       name: prometheus
+  helmfileRelease:
+    name: "stable/prometheus Helm Chart"
+    kind: yaml
+    spec:
+      file: "helmfile.d/prometheus.yaml"
+      key: "releases[0].name"
+      value: "prometheus"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
 
 targets:
   chartVersion:
@@ -21,10 +37,10 @@ targets:
       key: "releases[0].version"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
-        owner: "jenkins-infra"
-        repository: "charts"
-        token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-        username: "olblak"
-        branch: "master"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updateCli/updateCli.d/charts/stable-datadog.tpl
+++ b/updateCli/updateCli.d/charts/stable-datadog.tpl
@@ -11,6 +11,22 @@ conditions:
     spec:
       url: https://kubernetes-charts.storage.googleapis.com
       name: datadog
+  helmfileRelease:
+    name: "stable/datadog Helm Chart"
+    kind: yaml
+    spec:
+      file: "helmfile.d/datadog.yaml"
+      key: "releases[0].name"
+      value: "datadog"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
 
 targets:
   chartVersion:
@@ -21,10 +37,10 @@ targets:
       key: "releases[0].version"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
-        owner: "jenkins-infra"
-        repository: "charts"
-        token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-        username: "olblak"
-        branch: "master"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updateCli/updateCli.d/charts/stable-falco.tpl
+++ b/updateCli/updateCli.d/charts/stable-falco.tpl
@@ -11,6 +11,22 @@ conditions:
     spec:
       url: https://hub.helm.sh/charts
       name: falco
+  helmfileRelease:
+    name: "stable/falco Helm Chart"
+    kind: yaml
+    spec:
+      file: "helmfile.d/falco.yaml"
+      key: "releases[0].name"
+      value: "falco"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
 
 targets:
   chartVersion:
@@ -21,10 +37,10 @@ targets:
       key: "releases[0].version"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
-        owner: "jenkins-infra"
-        repository: "charts"
-        token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-        username: "olblak"
-        branch: "master"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updateCli/updateCli.d/charts/stable-jenkins.tpl
+++ b/updateCli/updateCli.d/charts/stable-jenkins.tpl
@@ -11,6 +11,22 @@ conditions:
     spec:
       url: https://kubernetes-charts.storage.googleapis.com
       name: jenkins
+  chartVersion:
+    name: "stable/jenkins Helm Chart"
+    kind: yaml
+    spec:
+      file: "charts/jenkins/requirements.yaml"
+      key: "dependencies[0].name"
+      value: "jenkins"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
 
 targets:
   chartVersion:
@@ -21,10 +37,10 @@ targets:
       key: "dependencies[0].version"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
-        owner: "jenkins-infra"
-        repository: "charts"
-        token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-        username: "olblak"
-        branch: "master"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updateCli/updateCli.d/charts/stable-nginx-ingress.tpl
+++ b/updateCli/updateCli.d/charts/stable-nginx-ingress.tpl
@@ -11,7 +11,38 @@ conditions:
     spec:
       url: https://kubernetes-charts.storage.googleapis.com
       name: nginx-ingress
-
+  publicHelmfileRelease:
+    name: "public stable/nginx-ingress Helm Chart"
+    kind: yaml
+    spec:
+      file: "helmfile.d/nginx-ingress.yaml"
+      key: "releases[0].name"
+      value:  "public-nginx-ingress"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  privateHelmfileRelease:
+    name: "private stable/nginx-ingress Helm Chart"
+    kind: yaml
+    spec:
+      file: "helmfile.d/nginx-ingress.yaml"
+      key: "releases[1].name"
+      value: "private-nginx-ingress"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
 targets:
   public-nginx-ingress:
     name: "public stable/nginx-ingress Helm Chart"
@@ -21,13 +52,13 @@ targets:
       key: "releases[0].version"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
-        owner: "jenkins-infra"
-        repository: "charts"
-        token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-        username: "olblak"
-        branch: "master"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
   private-nginx-ingress:
     name: "private stable/nginx-ingress Helm Chart"
     kind: yaml
@@ -36,10 +67,10 @@ targets:
       key: "releases[1].version"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
-        owner: "jenkins-infra"
-        repository: "charts"
-        token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-        username: "olblak"
-        branch: "master"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updateCli/updateCli.d/charts/stable-oauth2-proxy.tpl
+++ b/updateCli/updateCli.d/charts/stable-oauth2-proxy.tpl
@@ -11,6 +11,22 @@ conditions:
     spec:
       url: https://kubernetes-charts.storage.googleapis.com
       name: oauth2-proxy
+  helmfileRelease:
+    name: "stable/oauth2-proxy Helm Chart"
+    kind: yaml
+    spec:
+      file: "helmfile.d/oauth2-proxy.yaml"
+      key: "releases[0].name"
+      value: "oauth2-proxy"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
 
 targets:
   chartVersion:
@@ -21,10 +37,10 @@ targets:
       key: "releases[0].version"
     scm:
       github:
-        user: "updatecli"
-        email: "updatecli@olblak.com"
-        owner: "jenkins-infra"
-        repository: "charts"
-        token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-        username: "olblak"
-        branch: "master"
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updateCli/updateCli.d/updateCliPodTemplate.tpl
+++ b/updateCli/updateCli.d/updateCliPodTemplate.tpl
@@ -37,6 +37,7 @@ targets:
   imageTag:
     name: "Updatecli"
     kind: yaml
+    prefix: "olblak/updatecli:"
     spec:
       file: "PodTemplates.yaml"
       prefix: "olblak/updatecli:"

--- a/updateCli/updateCli.d/updateCliPodTemplate.tpl
+++ b/updateCli/updateCli.d/updateCliPodTemplate.tpl
@@ -1,0 +1,52 @@
+# Retrieve last updatecli version according Github Releases
+source:
+  kind: githubRelease
+  spec:
+    owner: "olblak"
+    repository: "updatecli"
+    token: "{{ requiredEnv .github.token }}"
+    username: "olblak"
+    version: "latest"
+conditions: 
+  # Ensure that container template name 'updatecli' is correctly defined in the PodTemplate
+  # and also that's defined in array location 1, as needed for the target 
+  containerSpec:
+    name: "Updatecli"
+    kind: yaml
+    spec:
+      file: "PodTemplates.yaml"
+      key: spec.containers[1].name
+      value: "updatecli"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "jenkins-infra"
+        repository: "charts"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "master"
+    # Ensure that a docker image for the latest version is available on dockerhub
+  docker:
+    name: "Docker Image Published on Registry"
+    kind: dockerImage
+    spec:
+      image: "olblak/updatecli"
+targets:
+  # Update updatecli version in the PodTemplate
+  imageTag:
+    name: "Updatecli"
+    kind: yaml
+    spec:
+      file: "PodTemplates.yaml"
+      prefix: "olblak/updatecli:"
+      key: spec.containers[1].image
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "jenkins-infra"
+        repository: "charts"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "master"

--- a/updateCli/updateCli.d/updateCliPodTemplate.tpl
+++ b/updateCli/updateCli.d/updateCliPodTemplate.tpl
@@ -8,8 +8,8 @@ source:
     username: "olblak"
     version: "latest"
 conditions: 
-  # Ensure that container template name 'updatecli' is correctly defined in the PodTemplate
-  # and also that's defined in array location 1, as needed for the target 
+  # Ensure that a container name 'updatecli' is correctly defined in the PodTemplate
+  # and located in the array position spec.containers[1], as needed for the target 
   containerSpec:
     name: "Updatecli"
     kind: yaml
@@ -26,7 +26,7 @@ conditions:
         token: "{{ requiredEnv .github.token }}"
         username: "{{ .github.username }}"
         branch: "master"
-    # Ensure that a docker image for the latest version is available on dockerhub
+    # Ensure that a docker image tag matching the value retrieved from the latest Github Release is available on dockerhub
   docker:
     name: "Docker Image Published on Registry"
     kind: dockerImage

--- a/updateCli/values.yaml
+++ b/updateCli/values.yaml
@@ -3,3 +3,6 @@ github:
   email: "updatebot@olblak.com"
   username: "olblak"
   token: "UPDATECLI_GITHUB_TOKEN" 
+  branch: "master"
+  owner: "jenkins-infra"
+  repository: "charts"


### PR DESCRIPTION
Depends on #307 

This pull request improves the way we automate version by:
* Adding updatecli configuration to automate updatecli version used in the PodTemplate
* Adding condition check for every updatecli configuration that update key/value based on array position, in order to make it more robust in case that position change for some reason.
* Fix keycloak configuration from keycloack to keycloak 
* Use template for scm configuration

This PR can easily be tested by running following commands:

```
export  UPDATECLI_GITHUB_TOKEN=<your_github_token>
sed 's/username: "olblak"/username: "<your_github_handle>"/' updateCli/values.yaml
docker run -i -t -e UPDATECLI_GITHUB_TOKEN=$UPDATECLI_GITHUB_TOKEN -v $PWD/updateCli:/updateCli --workdir /updateCli olblak/updatecli:v0.0.13 diff --config /updateCli/updateCli.d/ --values /updateCli/values.yaml
```