### PR TITLE
Set cache time to 1h for Changelog RSS and badge JSONs

### DIFF
--- a/charts/jenkinsio/templates/nginx-configmap.yaml
+++ b/charts/jenkinsio/templates/nginx-configmap.yaml
@@ -36,7 +36,7 @@ data:
         add_header Cache-Control "public";
       }
 
-      location ~* \.(html)$ {
+      location ~* \.(html|json|xml)$ {
         expires 1h;
         add_header Cache-Control "public";
       }


### PR DESCRIPTION
### What this PR does / why we need it:

This PR sets explicit cache time for all XML and JSON files returned by jenkins.io. Specifically, it should fix problem with 20day caching of Changelog RSS files and badges, but I thought it would not hurt to apply it globally

#### Which issue this PR fixes


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

