### PR TITLE
Use statefulset for prometheus alertmanager

### DIFF
--- a/config/default/prometheus.yaml
+++ b/config/default/prometheus.yaml
@@ -5,6 +5,9 @@ server:
   retention: "90d"
   statefulSet:
     enabled: true
+alertmanager:
+  statefulSet:
+    enabled: true
 extraScrapeConfigs: |
   - job_name: 'release-jenkins'
     metrics_path: /prometheus

--- a/helmfile.d/prometheus.yaml
+++ b/helmfile.d/prometheus.yaml
@@ -6,9 +6,9 @@ releases:
   namespace: prometheus
   chart: stable/prometheus
   wait: true
-  timeout: 600
+  timeout: 300
   version: 11.10.0
   force: false
-  atomic: true
+  atomic: false
   values:
   - "../config/default/prometheus.yaml"


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

Recent prometheus update was blocked because a volume was already attached the exist container, switch alertmanager to a statefulset better handle such usecases