### PR TITLE
[stable/plugins-site] Manual bump of plugin-site-api docker image since its not yet semver docker names

### DIFF
--- a/charts/plugin-site/Chart.yaml
+++ b/charts/plugin-site/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "1.11.1"
 description: A Helm chart for plugins.jenkins.io
 name: plugin-site
 maintainers:
   - name: timja
-version: 0.0.1
+version: 0.0.2

--- a/charts/plugin-site/values.yaml
+++ b/charts/plugin-site/values.yaml
@@ -7,7 +7,7 @@ backend:
   replicaCount: 1
   image:
     repository: jenkinsciinfra/plugin-site-api
-    tag: 153-290e61
+    tag: 157-cc4483
     pullPolicy: IfNotPresent
   port: 8080
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates to https://github.com/jenkins-infra/plugin-site-api/releases/tag/plugin-site-api-1.11.1
mainly fixes links for issues mentioned in github releases and switches accessing urls with client_id in queryy string to using basic auth

#### Which issue this PR fixes

see https://github.com/jenkins-infra/plugin-site-api/releases/tag/plugin-site-api-1.11.1

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md <-- does this only refer to new variables?
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

