### PR TITLE
[stable/plugin-site] Switch to newer plugin-site-api that uses github apps for api requests

### DIFF
--- a/charts/plugin-site/Chart.yaml
+++ b/charts/plugin-site/Chart.yaml
@@ -4,4 +4,5 @@ description: A Helm chart for plugins.jenkins.io
 name: plugin-site
 maintainers:
   - name: timja
-version: 0.0.1
+  - name: halkeye
+version: 0.0.3

--- a/charts/plugin-site/README.md
+++ b/charts/plugin-site/README.md
@@ -14,11 +14,15 @@ helm upgrade  -f values.yaml -f values.local.yaml  plugin-site .
 
 You need to define some configuration locally in a separate values file
 
+Make sure your pem key is converted from the format given by the website to pks#8
+
+openssl pkcs8 -topk8 -inform PEM -outform PEM -in devpluginsjenkinsio.2020-07-28.private-key.pem -out githubapp.pem -nocrypt
+
 Here's an example `values.local.yaml` file:
 ```yaml
 github:
-  clientId: <your-github-username>
-  clientSecret: <your-github-api-token>
+  appId: <your github app id>
+  appPrivateKey: <your github app key>
 
 ingress:
   enabled: true
@@ -27,8 +31,6 @@ ingress:
   hosts:
     - host: plugins-local.jenkins.io
 
-restApiUrl: http://plugins-local.jenkins.io/api
-
 # Should point to somewhere where the plugin-site's built public directory is
 htmlVolume:
   hostPath:
@@ -36,7 +38,7 @@ htmlVolume:
 
 ```
 
-The `ingress host` and the `restApiUrl` need to be reachable from both your desktop and from the k8s cluster
+The `ingress host` need to be reachable from both your desktop and from the k8s cluster
 
 ### Minikube gotchas
 

--- a/charts/plugin-site/templates/deployment-backend.yaml
+++ b/charts/plugin-site/templates/deployment-backend.yaml
@@ -11,6 +11,9 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        # subpath secrets don't get updates, and we want to restart on change anyways
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels: {{ include "plugin-site.labels" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
@@ -26,16 +29,13 @@ spec:
           image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
           env:
-            - name: GITHUB_CLIENT_ID
+            - name: GITHUB_APP_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ include "plugin-site.fullname" . }}
-                  key: github_client_id
-            - name: GITHUB_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "plugin-site.fullname" . }}
-                  key: github_client_secret
+                  key: github_app_id
+            - name: GITHUB_APP_PRIVATE_KEY
+              value: /secrets/github_app_key
             - name: JIRA_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -55,6 +55,10 @@ spec:
  {{- end }}
             - name: DATA_FILE_URL
               value: {{ .Values.dataFileUrl }}
+          volumeMounts:
+            - mountPath: /secrets/github_app_key
+              name: secrets
+              subPath: github_app_key
           ports:
               - name: backend
                 containerPort: {{ .Values.backend.port }}
@@ -87,3 +91,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      volumes:
+        - name: secrets
+          secret:
+            secretName: {{ include "plugin-site.fullname" . }}

--- a/charts/plugin-site/templates/secret.yaml
+++ b/charts/plugin-site/templates/secret.yaml
@@ -7,8 +7,8 @@ metadata:
 {{ include "plugin-site.labels" . | indent 4 }}
 type: Opaque
 data:
-  github_client_id: {{ required "github.clientId is required" .Values.github.clientId | b64enc }}
-  github_client_secret: {{ required "github.clientSecret is required" .Values.github.clientSecret | b64enc }}
+  github_app_id: {{ required "github.appId is required" .Values.github.appId | toString | b64enc }}
+  github_app_key: {{ required "github.appPrivateKey is required" .Values.github.appPrivateKey | toString | b64enc }}
   jira_username: {{ required "jira.username is required" .Values.jira.username | b64enc }}
   jira_password: {{ required "jira.password is required" .Values.jira.password | b64enc }}
 {{ if .Values.azureStorageAccountName }}

--- a/charts/plugin-site/values.yaml
+++ b/charts/plugin-site/values.yaml
@@ -7,7 +7,7 @@ backend:
   replicaCount: 1
   image:
     repository: jenkinsciinfra/plugin-site-api
-    tag: 153-290e61
+    tag: 159-921cc1
     pullPolicy: IfNotPresent
   port: 8080
   resources:
@@ -49,7 +49,12 @@ ingress:
     - path: /(.*)
       port: frontend
 
-#  annotations:
+  annotations:
+    # rewrite target is important to get the path regexes to work
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
 #    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
 #    "kubernetes.io/ingress.class": "public-ingress"
 #    "nginx.ingress.kubernetes.io/proxy-body-size": "500m"
@@ -70,11 +75,10 @@ tolerations: []
 affinity: {}
 
 dataFileUrl: https://ci.jenkins.io/job/Infra/job/plugin-site-api/job/generate-data/lastSuccessfulBuild/artifact/plugins.json.gzip
-restApiUrl: https://plugins.jenkins.io/api
 
 github:
-  clientId: ""
-  clientSecret: ""
+  appId: ""
+  appPrivateKey: ""
 
 jira:
   username: ""
@@ -85,9 +89,12 @@ jira:
 # htmlVolume:
 #   hostPath:
 #     path: /host
-htmlVolume:
+htmlVolume: {}
 
 # name of the azure storage account to be used
 azureStorageAccountName:
 # key for accessing the azure storage account
 azureStorageAccountKey:
+
+sentry:
+  dsn: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

Uses github app credentails for all api requests

#### Which issue this PR fixes

  - fixes # [INFRA-2691](https://issues.jenkins-ci.org/projects/INFRA/issues/INFRA-2691)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

