### PR TITLE
Add more projects to infra ci

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -148,6 +148,24 @@ jenkins:
                           }
                         }
                       }
+                  - script: >
+                      multibranchPipelineJob('jenkins-wiki-exporter') {
+                        displayName "Wiki Exporter"
+                        branchSources {
+                          github {
+                            id('2019081603')
+                            scanCredentialsId('github-access-token')
+                            repoOwner('jenkins-infra')
+                            repository('jenkins-wiki-exporter')
+                            includes('master')
+                          }
+                        }
+                        factory {
+                          workflowBranchProjectFactory {
+                            scriptPath('Jenkinsfile')
+                          }
+                        }
+                      }
               ldap-settings: |
                 jenkins:
                   securityRealm:

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -166,6 +166,24 @@ jenkins:
                           }
                         }
                       }
+                  - script: >
+                      multibranchPipelineJob('custom-distribution-service') {
+                        displayName "Custom Distribution Service"
+                        branchSources {
+                          github {
+                            id('2019081603')
+                            scanCredentialsId('github-access-token')
+                            repoOwner('jenkinsci')
+                            repository('custom-distribution-service')
+                            includes('master')
+                          }
+                        }
+                        factory {
+                          workflowBranchProjectFactory {
+                            scriptPath('Jenkinsfile')
+                          }
+                        }
+                      }
               ldap-settings: |
                 jenkins:
                   securityRealm:


### PR DESCRIPTION
the dockerhub credentials need to be copied over

https://github.com/jenkins-infra/pipeline-library/blob/c88ea135745ba7f3cd45f2a5a3590d7dccfb1606/vars/infra.groovy#L14

I *think* the default jenkins file will still  work since it should auto find a node since there are none with linux && high mem, but we will see

Might also need to setup a dind setup like i did or something
https://github.com/halkeye-docker/docker-jenkins/blob/master/jenkins.yaml#L52