### PR TITLE
[ldap] Remove ca.crt from statefulset volume

### DIFF
--- a/charts/ldap/templates/statefulset.yaml
+++ b/charts/ldap/templates/statefulset.yaml
@@ -126,8 +126,6 @@ spec:
           secret:
             secretName: ldap-tls
             items:
-              - key: ca.crt
-                path: {{ .Values.ldap.ssl.ca.filename }}
               - key: tls.crt
                 path: {{ .Values.ldap.ssl.crt.filename }}
               - key: tls.key

--- a/charts/ldap/values.yaml
+++ b/charts/ldap/values.yaml
@@ -34,7 +34,7 @@ ldap:
   debug_level: 256
   ssl:
     ca:
-      filename: cacert.pem
+      filename: ca.crt
       value: ''
     crt:
       filename: cert.pem


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

When we switched to Letsencrypt certifificate managed by certmanager, we lost the ability to use ca.crt as it's not generate. 
By now I just hotfix by manually updating the secret with the valid ca.crt but my fix will be override next time certmanager generate renew the certificate.

In order to merge this, I have to be sure that we don't try to set ca.crt from jenkins-infra/ldap
Pull request coming

The current pull request solves 
```Warning  FailedMount             2s (x23 over 30m)     kubelet, aks-agentpool-34540872-vmss000000  MountVolume.SetUp failed for volume "tls" : references non-existent secret key: ca.crt```