### PR TITLE
Add .docker/config.json to infra.ci

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -57,6 +57,11 @@ jenkins:
                             privateKeySource:
                               directEntry:
                                 privateKey: ${SSH_CHARTS_SECRETS_PRIVKEY}
+                        - file:
+                            scope: GLOBAL
+                            id: jenkins-dockerhub
+                            fileName: config.json
+                            secretBytes: ${base64:DOCKER_CONFIG}
               k8s-settings: |
                 jenkins:
                   clouds:


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

Add docker credentials to infra.ci

The secrets looks like 
```
secrets:
    DOCKER_HUB: |
        {
          "auths": {
            "https://index.docker.io/v1/": {
              "auth": "XXX"
            }
          },
        }

```
