### PR TITLE
Add timja to every sops file

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -11,6 +11,7 @@ creation_rules:
           pgp:
             - '88FABF5F307FB5870B6AD2E8A266F2D3F9D60C45' # Halkeye
             - '56D8342434B84E2D1CCF53D96E9A025D52210D3D' # Olblak
+            - '6699E555C6730CAED9083B7AD40F4AD2F55AF15F' # timja
 
     - path_regex: secrets/config/plugin-site/secrets.yaml
       key_groups:
@@ -70,3 +71,4 @@ creation_rules:
             version: '252fc7e646ac40f184ab4a6016484725'
           pgp:
             - '56D8342434B84E2D1CCF53D96E9A025D52210D3D' # Olblak
+            - '6699E555C6730CAED9083B7AD40F4AD2F55AF15F' # timja


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

This means that now by default when we create a new sops file then we also use timja publick GPG key on top of olblak and azure key vault