### PR TITLE
poll the docker builder jobs every 2 hours

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -156,6 +156,12 @@ jenkins:
                       ].each { config ->
                         multibranchPipelineJob(config[1]) {
                           displayName config[2]
+                          triggers {
+                            pollSCM {
+                              // poll every two hours until hooks are setup
+                              scmpoll_spec('H/2 * * * *')
+                            }
+                          }
                           branchSources {
                             branchSource {
                               source {


### PR DESCRIPTION
Right now there's no way for someone who doesn't have vpn access to make a release of wiki exporter or custom war package

Polling every 2 hours will let them do a normal git release process, which will create docker images for tags