### PR TITLE
Fix mirrorbits chart

### DIFF
--- a/charts/mirrorbits/templates/secret.yaml
+++ b/charts/mirrorbits/templates/secret.yaml
@@ -7,6 +7,16 @@ type: Opaque
 data:
   mirrorbits.conf: {{ .Values.mirrorbits.conf | b64enc }}
 
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mirrorbits.fullname" . }}-geoipupdate
+type: Opaque
+data:
+  GEOIPUPDATE_ACCOUNT_ID: {{ .Values.geoipupdate.account_id | b64enc }}
+  GEOIPUPDATE_LICENSE_KEY: {{ .Values.geoipupdate.license_key | b64enc }}
+
 {{ if $.Values.repository.secrets.enabled -}}
 ---
 apiVersion: v1
@@ -19,13 +29,3 @@ data:
   {{ $key }}: {{ $val | b64enc }}
   {{- end }}
 {{- end -}}
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "mirrorbits.fullname" . }}-geoipupdate
-type: Opaque
-data:
-  GEOIPUPDATE_ACCOUNT_ID: {{ .Values.geoipupdate.account_id | b64enc }}
-  GEOIPUPDATE_LICENSE_KEY: {{ .Values.geoipupdate.license_key | b64enc }}


### PR DESCRIPTION
For some reason I don't quite understand the document separator was getting stripped out with the secrets the other way, moved it around and it works