### PR TITLE
custom distribution manager 0.1-alpha-1 release

### DIFF
--- a/charts/custom-distribution-service/values.yaml
+++ b/charts/custom-distribution-service/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: jenkinsciinfra/custom-distribution-service
-  tag: 49d692d819bdc9c823e3531eb9c253eed35087da
+  tag: 0.1-alpha-1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
This provides the 0.1-alpha-1 release of the custom distribution manager.
It has bug fixes for many of initial untagged release.

