### PR TITLE
Revert "[updatecli] Update jetstack/cert-manager Helm Chart version to v1.0.1"

### DIFF
--- a/helmfile.d/cert-manager.yaml
+++ b/helmfile.d/cert-manager.yaml
@@ -6,7 +6,7 @@ releases:
     chart: jetstack/cert-manager
     namespace: cert-manager
     wait: true
-    version: v1.0.1
+    version: v1.0.0
     set:
       - name: installCRDs
         value: true


### PR DESCRIPTION
Reverts jenkins-infra/charts#463

it broke cert-manager and looks like fun to fix, tried for last 30 mins...