### PR TITLE
Codeowners and updatecli for incrementals and customize

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,3 +28,7 @@ chatbot.yaml @jenkins-infra/kubernetes @slide
 
 incrementals-publisher/ @jenkins-infra/kubernetes @slide
 incrementals-publisher.yaml @jenkins-infra/kubernetes @slide
+
+custom-distribution-service/ @jenkins-infra/kubernetes @martinda @kwhetstone @sladyn98
+custom-distribution-service.yaml @jenkins-infra/kubernetes @martinda @kwhetstone @sladyn98
+

--- a/charts/custom-distribution-service/Chart.yaml
+++ b/charts/custom-distribution-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: 0.1-alpha-1
 description: custom-distribution-service
 name: custom-distribution-service
 version: 0.1.0

--- a/charts/custom-distribution-service/templates/deployment.yaml
+++ b/charts/custom-distribution-service/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/custom-distribution-service/values.yaml
+++ b/charts/custom-distribution-service/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: jenkinsciinfra/custom-distribution-service
-  tag: 0.1-alpha-1
+  tag: "{{ .Chart.AppVersion }}"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/incrementals-publisher/Chart.yaml
+++ b/charts/incrementals-publisher/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "v1.0.0"
 description: incrementals-publisher
 name: incrementals-publisher
 version: 0.1.0

--- a/charts/incrementals-publisher/templates/deployment.yaml
+++ b/charts/incrementals-publisher/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/incrementals-publisher/values.yaml
+++ b/charts/incrementals-publisher/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: jenkinsciinfra/incrementals-publisher
-  tag: v1.0.0
+  tag: "{{ .Chart.AppVersion }}"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/updateCli/updateCli.d/custom-distribution-service.tpl
+++ b/updateCli/updateCli.d/custom-distribution-service.tpl
@@ -1,0 +1,31 @@
+---
+source:
+  kind: githubRelease
+  spec:
+    owner: "jenkinsci"
+    repository: "custom-distribution-service"
+    token: "{{ requiredEnv .github.token }}"
+    username: "olblak"
+    version: "latest"
+conditions:
+  docker:
+    name: "Docker Image Published on Registry"
+    kind: dockerImage
+    spec:
+      image: "jenkinsciinfra/custom-distribution-service"
+targets:
+  appVersion:
+    name: "Chart appVersion"
+    kind: yaml
+    spec:
+      file: "charts/custom-distribution-service/Chart.yaml"
+      key: appVersion
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "jenkins-infra"
+        repository: "charts"
+        token: "{{ requiredEnv .github.token }}"
+        username: "olblak"
+        branch: "master"

--- a/updateCli/updateCli.d/incrementals-publisher.tpl
+++ b/updateCli/updateCli.d/incrementals-publisher.tpl
@@ -1,0 +1,31 @@
+---
+source:
+  kind: githubRelease
+  spec:
+    owner: "jenkins-infra"
+    repository: "incrementals-publisher"
+    token: "{{ requiredEnv .github.token }}"
+    username: "olblak"
+    version: "latest"
+conditions:
+  docker:
+    name: "Docker Image Published on Registry"
+    kind: dockerImage
+    spec:
+      image: "jenkinsciinfra/incrementals-publisher"
+targets:
+  appVersion:
+    name: "Chart appVersion"
+    kind: yaml
+    spec:
+      file: "charts/incrementals-publisher/Chart.yaml"
+      key: appVersion
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "jenkins-infra"
+        repository: "charts"
+        token: "{{ requiredEnv .github.token }}"
+        username: "olblak"
+        branch: "master"


### PR DESCRIPTION
Hopefully I did this all right.

Updatecli should trigger a dependabot style PR whenever a new dockerhub tag and github release goes out.

Code owners should allow those people related to it to approve the release.

CC  @martinda @kwhetstone @sladyn98 @slide 