### PR TITLE
Switch to jenkinci/ helm charts and add webhook ingress

### DIFF
--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -5,6 +5,6 @@ Chart for Jenkins Core Release Environment environment is available [here](/helm
 
 ## Details
 
-The chart is based on the official [Helm Chart for Jenkins LTS](https://github.com/helm/charts/blob/master/stable/jenkins/values.yaml).
+The chart is based on the official [Helm Chart for Jenkins LTS](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml).
 It includes a number of plugins needed to run the Jenkins packaging and release Pipelines, and also the required system configuration and secrets.
 At the moment, the chart includes only the Jenkins master and Linux/Windows agents which are provisioned on-demand within Kubernetes.

--- a/charts/jenkins/requirements.lock
+++ b/charts/jenkins/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: jenkins
+  repository: https://charts.jenkins.io
+  version: 2.7.0
+digest: sha256:c35574c3bc767d6181197453caaa284f4ea05fb49ec2e38acc4e573340c7a084
+generated: "2020-09-22T21:30:48.126540043-07:00"

--- a/charts/jenkins/requirements.yaml
+++ b/charts/jenkins/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: jenkins
-    repository: https://kubernetes-charts.storage.googleapis.com
-    version: 2.5.4
+    repository: https://charts.jenkins.io
+    version: 2.7.0
     import-values:
       - child: jenkins.master
         parent: master

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -1,4 +1,4 @@
-# Defautl helm value https://github.com/helm/charts/blob/master/stable/jenkins/values.yaml
+# Default helm value https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml
 #
 clusterAdminEnabled: false
 jenkins:

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -268,3 +268,17 @@ jenkins:
             - hosts:
                 - infra.ci.jenkins.io
               secretName: infra.ci.jenkins.io-cert
+        secondaryingress:
+          enabled: true
+          paths:
+            - /github-webhook
+          hostName: infra-webhooks.ci.jenkins.io
+          annotations:
+            "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+            "kubernetes.io/ingress.class": "public-ingress"
+            "nginx.ingress.kubernetes.io/hsts": "true"
+            "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+          tls:
+            - hosts:
+                - infra-webhooks.ci.jenkins.io
+              secretName: infra-webhooks.ci.jenkins.io-cert

--- a/helmfile.d/jenkins-infra.yaml
+++ b/helmfile.d/jenkins-infra.yaml
@@ -4,6 +4,9 @@ helmDefaults:
   timeout: 600
   wait: true
 
+repositories:
+  - name: jenkins
+    url: https://charts.jenkins.io
 releases:
     - name: jenkins-infra
       chart: ../charts/jenkins

--- a/updateCli/updateCli.d/charts/stable-jenkins.tpl
+++ b/updateCli/updateCli.d/charts/stable-jenkins.tpl
@@ -9,10 +9,10 @@ conditions:
     name: "Jenkins Helm Chart Published on Registry"
     kind: helmChart
     spec:
-      url: https://kubernetes-charts.storage.googleapis.com
+      url: https://charts.jenkins.io
       name: jenkins
   chartVersion:
-    name: "stable/jenkins Helm Chart"
+    name: "jenkinsci/jenkins Helm Chart"
     kind: yaml
     spec:
       file: "charts/jenkins/requirements.yaml"
@@ -30,7 +30,7 @@ conditions:
 
 targets:
   chartVersion:
-    name: "stable/jenkins Helm Chart"
+    name: "jenkinsci/jenkins Helm Chart"
     kind: yaml
     spec:
       file: "charts/jenkins/requirements.yaml"


### PR DESCRIPTION
I'm afraid its going to force upgrades and break releases at the same time

So maybe a dry run somehow?

needs: https://github.com/jenkins-infra/azure/pull/160