### PR TITLE
Add docker-mirrorbits to infra.ci

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -167,6 +167,23 @@ jenkins:
                         }
                       }
                   - script: >
+                      multibranchPipelineJob('docker-mirrorbits') {
+                        displayName "Mirrorbits Docker Build"
+                        branchSources {
+                          github {
+                            id('2020102301')
+                            scanCredentialsId('github-access-token')
+                            repoOwner('jenkins-infra')
+                            repository('docker-mirrorbits')
+                          }
+                        }
+                        factory {
+                          workflowBranchProjectFactory {
+                            scriptPath('Jenkinsfile_k8s')
+                          }
+                        }
+                      }
+                  - script: >
                       [
                         ['jenkins-infra', 'jenkins-wiki-exporter', 'Wiki Exporter'],
                         ['jenkinsci', 'custom-distribution-service', 'Custom Distribution Service'],


### PR DESCRIPTION
mirrorbits is still build and publish on my own dockerhub organisation.
I just transfered this git repository -> https://github.com/jenkins-infra/docker-mirrorbits