### PR TITLE
Switch updatecli jenkins weekly update definition from maven to github release

### DIFF
--- a/updateCli/updateCli.d/jenkins-weekly-jdk11.tpl
+++ b/updateCli/updateCli.d/jenkins-weekly-jdk11.tpl
@@ -1,12 +1,15 @@
 source:
-  kind: maven
+  kind: githubRelease
   postfix: "-jdk11"
+  replaces:
+    - from: "jenkins-"
+      to: ""
   spec:
-    owner: "maven"
-    url: "repo.jenkins-ci.org"
-    repository: "releases"
-    groupID: "org.jenkins-ci.main"
-    artifactID: "jenkins-war"
+    owner: "jenkinsci"
+    repository: "jenkins"
+    username: "{{ .github.username }}"
+    token: "{{ requiredEnv .github.token }}"
+    version: latest
 conditions:
   docker:
     name: "Docker Image Published on Registry"


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

Currently `updatecli` use the Jenkins maven repository to detect when a new version is available.
Unfortunately this method doesn't allow us to detect changelog automatically which Github Release does.
The downside of this is that Github release is usual late compared to the maven repository.

A run would look like this, with the changelog section displayed in the pull request.


```
########################
# JENKINS-WEEKLY-JDK11 #
########################



SOURCE:
=======

✔ 'latest' github release version founded: jenkins-2.263


CHANGELOG:
==========

Release published on the 2020-10-20 14:33:17 +0000 UTC at the url https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.263
**Disclaimer**: This is an automatically generated changelog draft for Jenkins weekly releases. 
See https://jenkins.io/changelog/ for the official changelogs.

## 🐛 Major bug fixes

* [JENKINS-63958](https://issues.jenkins-ci.org/browse/JENKINS-63958) - Downgrade Jetty to 9.4.30.v20200611 to prevent wrong port in URLs (regression in 2.261) (#5019) @olamy
  * Winstone 5.11.1 changelog: https://github.com/jenkinsci/winstone/releases/tag/winstone-5.11.1
  * Root cause in Jetty: eclipse/jetty.project#5417

## 🚀 New features and improvements

* [INFRA-2751](https://issues.jenkins-ci.org/browse/INFRA-2751) - Remove TFS plugin from setup wizard (#5016) @daniel-beck
* Add missing French localization for the login page, setup wizard and the main page (#4995, #4996, #4997) @SoleneGK
* [JENKINS-49523](https://issues.jenkins-ci.org/browse/JENKINS-49523) - Clarify the list separator in file excludes fields  @egor1989
* Optimize memory allocations in TcpAgentListener, LogRotator and RunList (#5011, #5012) @gulyaev13

## 🐛 Bug Fixes

* Do not use `null` value for aria-hidden HTML attributes (#4919) @directhex
* Prevent resource leak in FileFingerprintStorage (#4992) @95jonpet 
* Reduce the prototype.js usage (#4987) @Wadeck 

All contributors: @95jonpet, @SoleneGK, @StefanSpieker, @Wadeck, @daniel-beck, @directhex, @egor1989, @gulyaev13, @jenkins-release-bot, @jtnord, @oguzhancevik, @olamy, @oleg-nenashev, @res0nance and @timja




CONDITIONS:
===========

✔ jenkins/jenkins:2.263-jdk11 available on the Docker Registry


TARGETS:
========

**Dry Run enabled**

Cloning git repository: https://github.com/jenkins-infra/charts.git
Downloaded in /tmp/jenkins-infra/charts/2.263

Enumerating objects: 62, done.
Counting objects: 100% (62/62), done.
Compressing objects: 100% (61/61), done.
Total 5098 (delta 33), reused 13 (delta 1), pack-reused 5036
already up-to-date

✔ Key 'jenkins.master.imageTag', from file '/tmp/jenkins-infra/charts/2.263/charts/jenkins/values.yaml', was updated from '2.264-jdk11' to '2.263-jdk11'

=============================

REPORTS:


⚠ JENKINS-WEEKLY-JDK11
	Source:
		✔  (githubRelease)
	Condition:
		✔  Docker Image Published on Registry(dockerImage)
	Target:
		⚠  jenkins/jenkins docker tag(yaml)




Run Summary
===========

1 job run
0 job succeed
0 job failed
1 job applied changes
```
