### PR TITLE
Revert "Switch updatecli jenkins weekly update definition from maven to github release"

### DIFF
--- a/updateCli/updateCli.d/jenkins-weekly-jdk11.tpl
+++ b/updateCli/updateCli.d/jenkins-weekly-jdk11.tpl
@@ -1,15 +1,12 @@
 source:
-  kind: githubRelease
+  kind: maven
   postfix: "-jdk11"
-  replaces:
-    - from: "jenkins-"
-      to: ""
   spec:
-    owner: "jenkinsci"
-    repository: "jenkins"
-    username: "{{ .github.username }}"
-    token: "{{ requiredEnv .github.token }}"
-    version: latest
+    owner: "maven"
+    url: "repo.jenkins-ci.org"
+    repository: "releases"
+    groupID: "org.jenkins-ci.main"
+    artifactID: "jenkins-war"
 conditions:
   docker:
     name: "Docker Image Published on Registry"


### PR DESCRIPTION
Reverts jenkins-infra/charts#575 as the jenkinsci/jenkins changelog is not the source of truth which delays our jenkins update