### PR TITLE
Add docker-mirrorbits to infra.ci to build jenkinsciinfra docker images

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -184,6 +184,23 @@ jenkins:
                         }
                       }
                   - script: >
+                      multibranchPipelineJob('docker-mirrorbits') {
+                        displayName "Mirrorbits Docker Build"
+                        branchSources {
+                          github {
+                            id('2020102301')
+                            scanCredentialsId('github-access-token')
+                            repoOwner('jenkins-infra')
+                            repository('docker-mirrorbits')
+                          }
+                        }
+                        factory {
+                          workflowBranchProjectFactory {
+                            scriptPath('Jenkinsfile_k8s')
+                          }
+                        }
+                      }
+                  - script: >
                       [
                         ['jenkins-infra', 'jenkins-wiki-exporter', 'Wiki Exporter'],
                         ['jenkinsci', 'custom-distribution-service', 'Custom Distribution Service'],


### PR DESCRIPTION
Currently, we are using a Mirrorbits docker image build and published to "olblak/mirrorbits" and the goal of this PR is to build and publish to jenkinsciinfra/mirrorbits from infra.ci