### PR TITLE
[stable/chatbot] Update to ircbot with Jira URL update

### DIFF
--- a/charts/chatbot/values.yaml
+++ b/charts/chatbot/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: jenkinsciinfra/ircbot
-  tag: 117-build21c9a7
+  tag: 123-builda9a7c7
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
#### What this PR does / why we need it:

https://github.com/jenkins-infra/ircbot/pull/92 updated the Jira URL in the ircbot post Jira migration to Linux FDN infrastructure. This provisions the bot with the correct tag to include the updated URL in the default bot configuration

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

