### PR TITLE
Disable temporary loki management

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -8,8 +8,9 @@ helmfiles:
   - path: "../helmfile.d/prometheus.yaml"
   - path: "../helmfile.d/cert-manager.yaml"
   - path: "../helmfile.d/falco.yaml"
-  - path: "../helmfile.d/loki.yaml"
-  - path: "../helmfile.d/promtail.yaml"
+#  Commented until we fix INFRA-2806
+#  - path: "../helmfile.d/loki.yaml"
+#  - path: "../helmfile.d/promtail.yaml"
   - path: "../helmfile.d/grafana.yaml"
   - path: "../helmfile.d/jenkins-wiki-exporter.yaml"
   - path: "../helmfile.d/polls.yaml"


### PR DESCRIPTION
For some reasons loki can't be updated, it complains about volume timeout issues but I couldn't anything wrong.
Considering that this service is not critical to the project, I prefer to temporarily disable it so we don't block other updates

```
 Unable to attach or mount volumes: unmounted volumes=[storage], unattached volumes=[storage loki-token-jqdgx config]: timed out waiting for the condition
```

