### PR TITLE
README: Use HTTPS for mirror in China

### DIFF
--- a/charts/mirrorbits/README.md
+++ b/charts/mirrorbits/README.md
@@ -67,7 +67,7 @@ mirrorbits add -rsync rsync://mirror.serverion.com/jenkins -ftp ftp://mirror.ser
 
 mirrorbits add -http https://mirror.esuni.jp/jenkins/ -admin-email "kuriyama@FreeBSD.org" esuni.jp
 
-mirrorbits add -http http://mirrors.tuna.tsinghua.edu.cn/jenkins/ -rsync rsync://mirrors.tuna.tsinghua.edu.cn/jenkins/ -admin-name "Yuzhi Wang" -admin-email "yuzhi.wang@tuna.tsinghua.edu.cn" tsinghua.edu.cn
+mirrorbits add -http https://mirrors.tuna.tsinghua.edu.cn/jenkins/ -rsync rsync://mirrors.tuna.tsinghua.edu.cn/jenkins/ -admin-name "Yuzhi Wang" -admin-email "yuzhi.wang@tuna.tsinghua.edu.cn" tsinghua.edu.cn
 
 mirrorbits add -http https://mirror.xmission.com/jenkins/ -rsync rsync://mirror.xmission.com/jenkins/  -ftp ftp://mirror.xmission.com/jenkins/ xmission.org
 


### PR DESCRIPTION
Match the other mirrors use of HTTPS.   The mirror in China is the only mirror using HTTP rather than HTTPS.

Confirmed that https://mirrors.tuna.tsinghua.edu.cn/jenkins/ is valid

#### What this PR does / why we need it:

https://groups.google.com/g/jenkins-infra/c/vm3FRYcsLA4/m/KIbM3HkbAgAJ reports that an attempt to redirect from https to http is denied.  Protocol downgrade is generally not allowed for redirects.

#### Which issue this PR fixes

  - fixes failure to install Debian package using the mirror in China

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

