### PR TITLE
Remove mirrorbits-database from default mirrorbits installation

### DIFF
--- a/config/default/mirrorbits.yaml
+++ b/config/default/mirrorbits.yaml
@@ -50,7 +50,7 @@ repository:
       storageClassName: azurefile
       resources:
         requests:
-          storage: 100Gi
+          storage: 500Gi
       selector:
         matchLabels:
           data: mirrorbits-binary
@@ -58,7 +58,7 @@ repository:
     enabled: true
     spec:
       capacity:
-        storage: 100Gi
+        storage: 500Gi
       storageClassName: azurefile
       accessModes:
         - ReadWriteMany
@@ -73,3 +73,5 @@ repository:
       - gid=1000
       - mfsymlinks
       - nobrl
+      - serverino
+      - cache=strict

--- a/helmfile.d/mirrorbits-database.yaml
+++ b/helmfile.d/mirrorbits-database.yaml
@@ -1,0 +1,15 @@
+repositories:
+  - name: bitnami
+    url: https://charts.bitnami.com/bitnami
+releases:
+  - name: mirrorbits-database
+    namespace: mirrorbits
+    version: 12.0.0
+    chart: bitnami/redis
+    wait: true
+    timeout: 600
+    atomic: true
+    values:
+      - "../config/default/mirrorbits-database.yaml"
+    secrets:
+      - "../secrets/config/mirrorbits-database/secrets.yaml"

--- a/helmfile.d/mirrorbits.yaml
+++ b/helmfile.d/mirrorbits.yaml
@@ -1,6 +1,3 @@
-repositories:
-  - name: bitnami
-    url: https://charts.bitnami.com/bitnami
 releases:
   - name: mirrorbits
     namespace: mirrorbits

--- a/helmfile.d/mirrorbits.yaml
+++ b/helmfile.d/mirrorbits.yaml
@@ -2,23 +2,12 @@ repositories:
   - name: bitnami
     url: https://charts.bitnami.com/bitnami
 releases:
-  - name: mirrorbits-database
-    namespace: mirrorbits
-    version: 12.1.1
-    chart: bitnami/redis
-    wait: true
-    timeout: 600
-    atomic: true
-    values:
-      - "../config/default/mirrorbits-database.yaml"
-    secrets:
-      - "../secrets/config/mirrorbits-database/secrets.yaml"
   - name: mirrorbits
     namespace: mirrorbits
     chart: ../charts/mirrorbits
     wait: true
     timeout: 600
-    atomic: true
+    atomic: false
     values:
       - "../config/default/mirrorbits.yaml"
     secrets:

--- a/updateCli/updateCli.d/charts/redis.tpl
+++ b/updateCli/updateCli.d/charts/redis.tpl
@@ -15,7 +15,7 @@ conditions:
     name: "bitnami/redis Helm Chart"
     kind: yaml
     spec:
-      file: "helmfile.d/mirrorbits.yaml"
+      file: "helmfile.d/mirrorbits-database.yaml"
       key: "releases[0].name"
       value: "mirrorbits-database"
     scm:
@@ -32,7 +32,7 @@ targets:
     name: "stable/redis Helm Chart"
     kind: yaml
     spec:
-      file: "helmfile.d/mirrorbits.yaml"
+      file: "helmfile.d/mirrorbits-database.yaml"
       key: "releases[0].version"
     scm:
       github:


### PR DESCRIPTION
We recently deploy a managed Redis database for get.jenkins.io so we don't need this Redis application running on publick8s cluster but it remains useful for local development so I am keeping the Helmfile configuration but I remove it from the cluster.

I am also increasing the size of the Mirrorbits database to 500GB as the current situation uses +-350GB