### PR TITLE
Use updatecli docker image from ghcr.io instead of dockerhub

### DIFF
--- a/PodTemplates.yaml
+++ b/PodTemplates.yaml
@@ -59,7 +59,7 @@ spec:
       env:
         - name: "HOME"
           value: "/home/helm"
-      image: "olblak/updatecli:v0.0.26"
+      image: "ghcr.io/olblak/updatecli:v0.0.26"
       imagePullPolicy: "Always"
       name: "updatecli"
       resources:

--- a/updateCli/updateCli.d/updateCliPodTemplate.tpl
+++ b/updateCli/updateCli.d/updateCliPodTemplate.tpl
@@ -31,7 +31,8 @@ conditions:
     name: "Docker Image Published on Registry"
     kind: dockerImage
     spec:
-      image: "olblak/updatecli"
+      image: "ghcr.io/olblak/updatecli"
+      token: "{{ requiredEnv .github.token }}"
 targets:
   # Update updatecli version in the PodTemplate
   imageTag:
@@ -40,7 +41,7 @@ targets:
     prefix: "olblak/updatecli:"
     spec:
       file: "PodTemplates.yaml"
-      prefix: "olblak/updatecli:"
+      prefix: "ghcr.io/olblak/updatecli:"
       key: spec.containers[1].image
     scm:
       github:


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

I moved olblak/updatecli docker image from dockerhub to ghcr.io to not be affected by Dockerhub rate limit 