### PR TITLE
Do not check datadog docker image tag

### DIFF
--- a/config/default/datadog.yaml
+++ b/config/default/datadog.yaml
@@ -16,6 +16,7 @@ agents:
   image:
     repository: "jenkinsciinfra/datadog@sha256"
     tag: "295a43c8e1dc531e525e6d2c99fac92f69d486e8348e4f1f83d38d54503db8ff"
+    doNotCheckTag: true # we must skip version test while we use the docker image digest
 clusterAgents:
   enabled: true
   metricsProvider:


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

The default behavior for Datadog helm chart is to check the docker image tag used which IMHO is a very good idea but I need a little bit more time to build a custom docker image with an appropriate tag 

```
==> Linting /tmp/253114755/datadog/2.5.4/datadog/datadog/datadog

[ERROR] templates/: template: datadog/templates/_helpers.tpl:16:12: executing "check-version" at <semverCompare "^6.19.0-0 || ^7.19.0-0" $version>: error calling semverCompare: Invalid Semantic Version

```