### PR TITLE
chore(deps): bump jenkins chart from 2.7.1 to 2.19.0

### DIFF
--- a/charts/jenkins/requirements.lock
+++ b/charts/jenkins/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: jenkins
   repository: https://charts.jenkins.io
-  version: 2.7.1
-digest: sha256:c2ef530a52704877934a9c44c4ef05227fbdc872e4fce138c64929f2a3a480ac
-generated: "2020-09-29T16:51:16.633783203-07:00"
+  version: 2.19.0
+digest: sha256:1b6e2e95be57c83015dff12b4f2e2308b92c888aeacee2deb6764501cfb57aed
+generated: "2020-12-02T10:42:42.338018Z"

--- a/charts/jenkins/requirements.yaml
+++ b/charts/jenkins/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: jenkins
     repository: https://charts.jenkins.io
-    version: 2.7.1
+    version: 2.19.0
     import-values:
       - child: jenkins.master
         parent: master


### PR DESCRIPTION
This is the latest 2.x chart before jumping to the 3.x release.  This
may also aid some of the issues updating jcasc config on infra/releases.

<!--
Thank you for contributing to jenkins-infra/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkins-infra/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm-www/tree/master/content/en/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/jenkins-infra/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Jenkins job
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart
- [ ] `CODEOWNERS` is updated
- [ ] If secrets are needed, `.sops.yaml` must be updated with appropriated public gpg key ID, and full public gpg key must be provided to @olblak

#### What this PR does / why we need it:

#### Which issue this PR fixes

  - fixes # [INFRA-XXXX](https://issues.jenkins-ci.org/projects/INFRA/issues/INFRA-XXXX)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)