### PR TITLE
UpdateCLI runs every 30 min, regular apply/lint happens on all branches

### DIFF
--- a/Jenkinsfile_updatecli_k8s
+++ b/Jenkinsfile_updatecli_k8s
@@ -19,6 +19,7 @@ pipeline {
   }
 
   triggers {
+    cron 'H/30 * * * *'
   }
 
   stages {
@@ -39,35 +40,25 @@ pipeline {
         }
       }
     }
-    stage('Prepare Environment'){
+    stage('Check Configuration Update') {
       when { branch 'master' }
+      environment {
+        UPDATECLI_GITHUB_TOKEN  = credentials('updatecli-github-token')
+      }
       steps {
-        container('helmfile'){
-          sh 'mkdir -p $HOME $HOME/.config'
+        container('updatecli') {
+          sh 'updatecli diff --config ./updateCli/updateCli.d --values ./updateCli/values.yaml'
         }
       }
     }
-    stage('Test Lint'){
+    stage('Apply Configuration Update') {
       when { branch 'master' }
-      steps {
-        container('helmfile'){
-          sh 'helmfile -f clusters/publick8s.yaml lint'
-        }
+      environment {
+        UPDATECLI_GITHUB_TOKEN  = credentials('updatecli-github-token')
       }
-    }
-    stage('Diff'){
-      when { branch 'master' }
       steps {
-        container('helmfile'){
-          sh 'helmfile -f clusters/publick8s.yaml diff --suppress-secrets'
-        }
-      }
-    }
-    stage('Apply'){
-      when { branch 'master' }
-      steps {
-        container('helmfile'){
-          sh 'helmfile -f clusters/publick8s.yaml apply --suppress-secrets'
+        container('updatecli') {
+          sh 'updatecli apply --config ./updateCli/updateCli.d --values ./updateCli/values.yaml'
         }
       }
     }

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -131,6 +131,25 @@ jenkins:
                   }
                 }
             - script: >
+                multibranchPipelineJob('k8smgmt-updatecli') {
+                  displayName "Update Manager for k8s cluster"
+                  description "Update Manager for k8s cluster"
+                  branchSources {
+                    github {
+                      id('2019081602')
+                      scanCredentialsId('github-access-token')
+                      repoOwner('jenkins-infra')
+                      repository('charts')
+                      includes('master')
+                    }
+                  }
+                  factory {
+                    workflowBranchProjectFactory {
+                      scriptPath('Jenkinsfile_updatecli_k8s')
+                    }
+                  }
+                }
+            - script: >
                 multibranchPipelineJob('plugin-site') {
                   displayName "Plugin Site"
                   branchSources {


### PR DESCRIPTION
Unless your watching the CI jobs, its pretty hard to see when something was changed (for example chatbot).

Split the updatecli job and the helmfile job so one is cron based, one is commit based.

Could setup helmfile to pin chart versions and get updatecli to bump the chart version.