### PR TITLE
Update jenkins jcasc permission

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -339,7 +339,7 @@ jenkins:
           jenkins:
             authorizationStrategy:
               globalMatrix:
-                grantedPermissions:
+                permissions:
                   - "Overall/Administer:admins"
                   - "Overall/SystemRead:all"
                   - "Overall/Read:all"

--- a/config/default/jenkins-release.yaml
+++ b/config/default/jenkins-release.yaml
@@ -367,7 +367,7 @@ jenkins:
           jenkins:
             authorizationStrategy:
               globalMatrix:
-                grantedPermissions:
+                permissions:
                   - "Overall/Administer:release-core"
                   - "Overall/SystemRead:all"
                   - "Overall/Read:all"


### PR DESCRIPTION
Attempt to fix, this PR hasn't been tested yet

```
2020-12-11 14:41:47.473+0000 [id=28]	WARNING	o.j.p.m.i.c.MatrixAuthorizationStrategyConfigurator#setPermissionsDeprecated: Loading deprecated attribute 'grantedPermissions' for instance of 'hudson.security.GlobalMatrixAuthorizationStrategy'. Use 'permissions' instead.
```