### PR TITLE
revert: on jenkins-infra/charts only build branches that are PRs

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -122,11 +122,6 @@ jenkins:
                       scanCredentialsId('github-access-token')
                       repoOwner('jenkins-infra')
                       repository('charts')
-                      traits {
-                        gitHubBranchDiscovery {
-                          strategyId(2) // 2-only branches that are pull requests
-                        }
-                      }
                     }
                   }
                   factory {


### PR DESCRIPTION
Reverts jenkins-infra/charts#692