### PR TITLE
Add a new multibranch job for jenkins-infra/docker-builder repo

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -217,6 +217,23 @@ jenkins:
                   }
                 }
             - script: >
+                multibranchPipelineJob('docker-builder') {
+                  displayName "Docker Builder's Docker Build"
+                  branchSources {
+                    github {
+                      id('2020122201')
+                      scanCredentialsId('github-access-token')
+                      repoOwner('jenkins-infra')
+                      repository('docker-builder')
+                    }
+                  }
+                  factory {
+                    workflowBranchProjectFactory {
+                      scriptPath('Jenkinsfile_k8s')
+                    }
+                  }
+                }
+            - script: >
                 multibranchPipelineJob('aws') {
                   displayName "AWS Infra"
                   branchSources {


### PR DESCRIPTION

#### What this PR does / why we need it:

Add a new multibranch pipeline for repository jenkins-infra/docker-builder

#### Which issue this PR fixes

 - step of [INFRA-2860](https://issues.jenkins-ci.org/projects/INFRA/issues/INFRA-2860)

#### Special notes for your reviewer:

Enable CI for https://github.com/jenkins-infra/docker-terraform.


