### PR TITLE
Update Helm Stable's repository URL to the new location

### DIFF
--- a/charts/nexus/requirements.lock
+++ b/charts/nexus/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: sonatype-nexus
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 1.18.4
-digest: sha256:2ee2d6d747813ec5564db9144f9dfd3fd3f537555fd61e168b76ea5f5c661306
-generated: 2019-06-25T15:12:53.033243911+02:00
+digest: sha256:f63c61e07284a72089320d6c98f9a37ec4315d27da382265255f45bd89582d72
+generated: "2021-01-04T12:01:14.966001+01:00"

--- a/charts/nexus/requirements.yaml
+++ b/charts/nexus/requirements.yaml
@@ -2,7 +2,7 @@
 dependencies:
   - name: sonatype-nexus
     alias: nexus
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
     version: 1.18.4
     import-values:
       - child: nexus.statefulset

--- a/helmfile.d/00-repositories.yaml
+++ b/helmfile.d/00-repositories.yaml
@@ -6,4 +6,4 @@ repositories:
   - name: loki
     url: https://grafana.github.io/loki/charts
   - name: stable
-    url: https://kubernetes-charts.storage.googleapis.com
+    url: https://charts.helm.sh/stable

--- a/helmfile.d/00-repositories.yaml
+++ b/helmfile.d/00-repositories.yaml
@@ -1,6 +1,6 @@
 repositories:
   - name: incubator
-    url: https://kubernetes-charts-incubator.storage.googleapis.com
+    url: https://charts.helm.sh/incubator
   - name: jetstack
     url: https://charts.jetstack.io
   - name: loki

--- a/helmfile.d/dex.yaml
+++ b/helmfile.d/dex.yaml
@@ -1,6 +1,6 @@
 repositories:
   - name: stable
-    url: https://kubernetes-charts.storage.googleapis.com
+    url: https://charts.helm.sh/stable
 releases:
     - name: private-dex
       chart: stable/dex

--- a/helmfile.d/nginx-ingress.yaml
+++ b/helmfile.d/nginx-ingress.yaml
@@ -1,6 +1,6 @@
 repositories:
 - name: stable
-  url: https://kubernetes-charts.storage.googleapis.com
+  url: https://charts.helm.sh/stable
 releases:
 - name: public-nginx-ingress
   chart: stable/nginx-ingress

--- a/updateCli/updateCli.d/charts/dex.tpl
+++ b/updateCli/updateCli.d/charts/dex.tpl
@@ -1,7 +1,7 @@
 source:
   kind: helmChart
   spec:
-    url: https://kubernetes-charts.storage.googleapis.com
+    url: https://charts.helm.sh/stable
     name: dex
 
 conditions:
@@ -9,7 +9,7 @@ conditions:
     name: "Dex helm chart available on Registry"
     kind: helmChart
     spec:
-      url: https://kubernetes-charts.storage.googleapis.com
+      url: https://charts.helm.sh/stable
       name: dex
   helmfileRelease:
     name: "stable/dex Helm Chart"

--- a/updateCli/updateCli.d/charts/stable-nginx-ingress.tpl
+++ b/updateCli/updateCli.d/charts/stable-nginx-ingress.tpl
@@ -1,7 +1,7 @@
 source:
   kind: helmChart
   spec:
-    url: https://kubernetes-charts.storage.googleapis.com
+    url: https://charts.helm.sh/stable
     name: nginx-ingress
 
 conditions:
@@ -9,7 +9,7 @@ conditions:
     name: "Nging ingress helm chart available on Registry"
     kind: helmChart
     spec:
-      url: https://kubernetes-charts.storage.googleapis.com
+      url: https://charts.helm.sh/stable
       name: nginx-ingress
   publicHelmfileRelease:
     name: "public stable/nginx-ingress Helm Chart"

--- a/updateCli/updateCli.d/charts/stable-oauth2-proxy.tpl
+++ b/updateCli/updateCli.d/charts/stable-oauth2-proxy.tpl
@@ -1,7 +1,7 @@
 source:
   kind: helmChart
   spec:
-    url: https://kubernetes-charts.storage.googleapis.com
+    url: https://charts.helm.sh/stable
     name: oauth2-proxy
 
 conditions:
@@ -9,7 +9,7 @@ conditions:
     name: Ooauth2-proxy helm chart available on Registry"
     kind: helmChart
     spec:
-      url: https://kubernetes-charts.storage.googleapis.com
+      url: https://charts.helm.sh/stable
       name: oauth2-proxy
   helmfileRelease:
     name: "stable/oauth2-proxy Helm Chart"


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the URL location of the Helm stable repository, as per <https://helm.sh/blog/new-location-stable-incubator-charts/>.

It fixes the following CI error thrown by the "Lint" stage (<https://infra.ci.jenkins.io/blue/organizations/jenkins/k8smgmt/detail/master/8761/pipeline>):

```text
Adding repo stable https://kubernetes-charts.storage.googleapis.com

in clusters/publick8s.yaml: in .helmfiles[2]: in ../helmfile.d/nginx-ingress.yaml: the following cmd exited with status 1:

  /usr/local/bin/helm helm repo add stable https://kubernetes-charts.storage.googleapis.com


  Error: looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden

script returned exit code 1
```

#### Which issue this PR fixes

N/A.

#### Special notes for your reviewer:

Happy New Year  \o/
