### PR TITLE
chore: for jenkins-infra/charts build only master and PRs

### DIFF
--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -60,6 +60,7 @@ jenkins:
       - github-api
       - github-branch-source
       - github-checks
+      - github-label-filter
       - inline-pipeline
       - jira
       - job-dsl

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -1,3 +1,4 @@
+---
 clusterAdminEnabled: true
 jenkins:
   agent:
@@ -127,6 +128,26 @@ jenkins:
                   factory {
                     workflowBranchProjectFactory {
                       scriptPath('Jenkinsfile_k8s')
+                    }
+                  }
+                  configure { node ->
+                    def traits = node / 'sources' / 'data' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
+                    traits << 'org.jenkinsci.plugins.github__branch__source.BranchDiscoveryTrait' {
+                      strategyId(1)
+                    }
+                    traits << 'org.jenkinsci.plugins.github__branch__source.OriginPullRequestDiscoveryTrait' {
+                      strategyId(1)
+                    }
+                    traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
+                      strategyId(1)
+                      trust(class: 'org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission')
+                    }
+                    traits << 'jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait' {
+                      includes('main master PR-*')
+                      excludes()
+                    }
+                    traits << 'org.jenkinsci.plugins.github.label.filter.PullRequestLabelsBlackListFilterTrait' {
+                      labels('on-hold')
                     }
                   }
                 }

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -147,7 +147,7 @@ jenkins:
                       excludes()
                     }
                     traits << 'org.jenkinsci.plugins.github.label.filter.PullRequestLabelsBlackListFilterTrait' {
-                      labels('on-hold')
+                      labels('on-hold ci-skip')
                     }
                   }
                 }


### PR DESCRIPTION
this will also exclude PRs labels as 'on-hold' to stop building some of
the older PRs for that repository.

#### What this PR does / why we need it:

Currently all branches (&PRs) for jenkins-infra/charts are being built.
This PR limits them to be master/main & PRs only.  PRs with the label
`on-hold` are also excluded.