### PR TITLE
Build a rsync server docker image from infra.ci

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -221,6 +221,23 @@ jenkins:
                   }
                 }
             - script: >
+                multibranchPipelineJob('docker-rsyncd') {
+                  displayName "Rsyncd Docker Build"
+                  branchSources {
+                    github {
+                      id('2021010601')
+                      scanCredentialsId('github-access-token')
+                      repoOwner('jenkins-infra')
+                      repository('docker-rsyncd')
+                    }
+                  }
+                  factory {
+                    workflowBranchProjectFactory {
+                      scriptPath('Jenkinsfile_k8s')
+                    }
+                  }
+                }
+            - script: >
                 multibranchPipelineJob('docker-terraform') {
                   displayName "Terraform Docker Build"
                   branchSources {

--- a/config/default/jenkins-release.yaml
+++ b/config/default/jenkins-release.yaml
@@ -361,7 +361,7 @@ jenkins:
                   description "Jenkins Core Release"
                   branchSources {
                     github {
-                      id('2020121601')
+                      id('2020121702')
                       scanCredentialsId('github-access-token')
                       repoOwner('jenkins-infra')
                       repository('release')


### PR DESCRIPTION
Build a rsync server docker image from infra.ci
This image will be used in the mirror helm chart, as we need a read-only rsync server to add the mirror to mirrorbits 