### PR TITLE
Infra Instance: Add github tag discovery and build strategy for docker-* jobs

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -178,6 +178,19 @@ jenkins:
                       repoOwner("jenkins-infra")
                       apiUri("https://api.github.com")
                       credentialsId('github-access-token')
+
+                      traits {
+                        gitHubTagDiscovery()
+                        cloneOptionTrait {
+                          extension {
+                            shallow(false)
+                            noTags(false)
+                            reference('')
+                            timeout(10)
+                            honorRefspec(true)
+                          }
+                        }
+                      }
                     }
                   }
 
@@ -191,6 +204,13 @@ jenkins:
                   projectFactories {
                     workflowMultiBranchProjectFactory {
                       scriptPath('Jenkinsfile_k8s')
+                    }
+                  }
+
+                  buildStrategies {
+                    buildTags {
+                      atLeastDays("0")
+                      atMostDays("7")
                     }
                   }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Common work with @olblak and @garethjevans around discovering, building and triggering jobs based on GitHub tags for the "docker-*" repositories of the infra.ci.jenkins.io instance.

It allows this instruction to work as expected: https://github.com/jenkins-infra/pipeline-library/blob/510aaa9f9d228fc29a1097b6086ff9038ba695d3/vars/buildDockerAndPublishImage.groovy#L156

#### Which issue this PR fixes

 N/A

#### Special notes for your reviewer:

 N/A

