### PR TITLE
Detect jenkins version update using github releases

### DIFF
--- a/updateCli/updateCli.d/jenkins-weekly-jdk11.tpl
+++ b/updateCli/updateCli.d/jenkins-weekly-jdk11.tpl
@@ -1,21 +1,25 @@
 source:
-  kind: maven
+  name: "Retrieve latest jenkins weekly version"
+  kind: githubRelease
   postfix: "-jdk11"
+  replaces:
+    - from: "jenkins-"
+      to: ""
   spec:
-    owner: "maven"
-    url: "repo.jenkins-ci.org"
-    repository: "releases"
-    groupID: "org.jenkins-ci.main"
-    artifactID: "jenkins-war"
+    owner: "jenkinsci"
+    repository: "jenkins"
+    token: "{{ requiredEnv .github.token }}"
+    username: "{{ .github.username }}"
+    version: "latest"
 conditions:
   docker:
-    name: "Docker Image Published on Registry"
+    name: "Test jenkins/jenkins docker image tag"
     kind: dockerImage
     spec:
       image: "jenkins/jenkins"
 targets:
   imageTag:
-    name: "jenkins/jenkins docker tag"
+    name: "Update jenkins/jenkins docker image tag"
     kind: yaml
     spec:
       file: "charts/jenkins/values.yaml"
@@ -24,8 +28,8 @@ targets:
       github:
         user: "{{ .github.user }}"
         email: "{{ .github.email }}"
-        owner: "jenkins-infra"
-        repository: "charts"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
         token: "{{ requiredEnv .github.token }}"
         username: "{{ .github.username }}"
         branch: "master"


### PR DESCRIPTION
Detect jenkins version update using github releases instead of maven releases, the purpose is have access to changelog information. Output looks like 

```
+++++++++++
+ PREPARE +
+++++++++++

Cloning git repository: https://github.com/jenkins-infra/charts.git in /tmp/updatecli/jenkins-infra/charts
Enumerating objects: 23, done.
Counting objects: 100% (23/23), done.
Compressing objects: 100% (21/21), done.
Total 5787 (delta 8), reused 8 (delta 2), pack-reused 5764
Fetching remote branches


+++++++
+ RUN +
+++++++



########################
# JENKINS-WEEKLY-JDK11 #
########################



SOURCE:
=======

✔ 'latest' github release version founded: jenkins-2.274


CHANGELOG:
==========

Release published on the 2021-01-05 18:41:56 +0000 UTC at the url https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.274
**Disclaimer**: This is an automatically generated changelog draft for Jenkins weekly releases. 
See https://jenkins.io/changelog/ for the official changelogs.
For `changelog.yaml` drafts see GitHub action artifacts attached to release commits.

* Ignore jakarta.mail upgrades with dependabot (#5150) @timja

## 🚀 New features and improvements

* [JENKINS-58101](https://issues.jenkins-ci.org/browse/JENKINS-58101) - Cache blockage reasons when considering parked executors (#5082) @res0nance

## 🐛 Bug Fixes

* [JENKINS-64439](https://issues.jenkins-ci.org/browse/JENKINS-64439) - "positive-number" field validator accepts non valid java numbers (#5145) @benebsiny

## 📦 Dependency updates

* Bump actions/upload-artifact from v2.2.1 to v2.2.2 (#5151) @dependabot
* Bump jnr-posix from 3.0.45 to 3.1.4 (#5129) @dependabot
* Bump jna from 5.3.1 to 5.6.0 (#5125) @dependabot

All contributors: @StefanSpieker, @basil, @benebsiny, @dependabot, @dependabot[bot], @jenkins-release-bot, @oleg-nenashev, @res0nance and @timja




CONDITIONS:
===========

✔ jenkins/jenkins:2.274-jdk11 available on the Docker Registry


TARGETS:
========

**Dry Run enabled**


✔ Key 'jenkins.master.imageTag', from file '/tmp/updatecli/jenkins-infra/charts/charts/jenkins/values.yaml', already set to 2.274-jdk11, nothing else need to be done

=============================

REPORTS:


✔ JENKINS-WEEKLY-JDK11
	Source:
		✔  Retrieve latest jenkins weekly version(githubRelease)
	Condition:
		✔  Test jenkins/jenkins docker image tag(dockerImage)
	Target:
		✔  Update jenkins/jenkins docker image tag(yaml)




Run Summary
===========

1 job run
1 job succeed
0 job failed
0 job applied changes
```

