### PR TITLE
Add public IP to mirror.azure.jenkins.io

### DIFF
--- a/charts/mirror/values.yaml
+++ b/charts/mirror/values.yaml
@@ -44,6 +44,7 @@ service:
 #    IP:
     whitelisted_sources:
       - 52.167.253.43/32
+      - 52.202.51.185/32
 
 #ingress:
 #  enabled: true

--- a/config/default/mirror.yaml
+++ b/config/default/mirror.yaml
@@ -31,3 +31,7 @@ persistent:
       resources:
         requests:
           storage: 200Gi
+
+service:
+  rsyncd:
+    type: LoadBalancer


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

Make mirror.azure.jenkins.io  reachable from the internet but only allow connection from get.jenkins.io and pkg.jenkins.io 