### PR TITLE
Switch rsyncd to digest and add updatecli config

### DIFF
--- a/charts/mirror/values.yaml
+++ b/charts/mirror/values.yaml
@@ -23,8 +23,8 @@ images:
     tag: latest
     pullPolicy: Always
   rsyncd:
-    repository: jenkinsciinfra/rsyncd
-    tag: latest
+    repository: jenkinsciinfra/rsyncd@sha256
+    tag: 7d932c3cec64b3e67c6e64e1ff85b1588c305d540af4aac426628f38f6fd17af
     pullPolicy: Always
 
 imagePullSecrets: []

--- a/updateCli/updateCli.d/mirror-rsyncd.tpl
+++ b/updateCli/updateCli.d/mirror-rsyncd.tpl
@@ -1,0 +1,40 @@
+source:
+  name: Get latest jenkinsciinfra/rsyncd:latest image digest
+  kind: dockerDigest
+  spec:
+    image: "jenkinsciinfra/rsyncd"
+    tag: "latest"
+
+conditions:
+  defaultCiDockerImage:
+    name: "Ensure mirror rsyncd image name is set to jenkinsciinfra/rsyncd@sha256"
+    kind: yaml
+    spec:
+      file: "charts/mirror/values.yaml"
+      key: "images.rsyncd.tag"
+      value: "jenkinsciinfra/rsyncd@sha256"
+    scm:
+      github:
+        user: "{{ .github.user }}" 
+        email: "{{ .github.email }}" 
+        owner: "{{ .github.owner }}" 
+        repository: "{{ .github.repository }}" 
+        token: "{{ requiredEnv .github.token }}" 
+        username: "{{ .github.username }}" 
+        branch: "{{ .github.branch }}" 
+targets:
+  imageTag:
+    name: "Update mirror helm chart with latest rsyncd image digest"
+    kind: yaml
+    spec:
+      file: "charts/mirror/values.yaml"
+      key: "images.rsyncd.tag"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository}}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>
We are working to use git tag for docker image name but at least for the moment, I am going to switch to image digest so we keep the rsync image up to date.