### PR TITLE
Bugfix 🐛: Stop filtering branch names when scanning docker-* repos 

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -219,10 +219,6 @@ jenkins:
                     traits << 'jenkins.scm.impl.trait.RegexSCMSourceFilterTrait' {
                       regex('docker-.*')
                     }
-                    traits << 'jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait' {
-                      includes('main master PR-*')
-                      excludes()
-                    }
                     traits << 'org.jenkinsci.plugins.github__branch__source.BranchDiscoveryTrait' {
                       strategyId(1)
                     }


### PR DESCRIPTION

#### What this PR does / why we need it:

Allow tag builds (as tag discovery is working correctly since #740 ) for the `docker-*` builds.

Filtering out by names within the repository was implicitly filtering out the tag names.

#### Which issue this PR fixes

N/A

