### PR TITLE
Azure mirror

### DIFF
--- a/charts/mirrorbits/README.md
+++ b/charts/mirrorbits/README.md
@@ -81,6 +81,9 @@ mirrorbits add -http https://ftp.yz.yamagata-u.ac.jp/pub/misc/jenkins/ -rsync rs
 mirrorbits add -http https://mirror.gruenehoelle.nl/jenkins/ -rsync rsync://esme.gruenehoelle.nl/mirror/jenkins/ -admin-name "gunter@grodotzki.com" -admin-email "gunter@grodotzki.com" gruenehoelle.nl
 
 mirrorbits add -http https://ftp.halifax.rwth-aachen.de/jenkins/ -rsync rsync://ftp.halifax.rwth-aachen.de/jenkins/ -ftp ftp://ftp.halifax.rwth-aachen.de/jenkins/ -admin-name "ftp@halifax.rwth-aachen.de" -admin-email "ftp@halifax.rwth-aachen.de" rwth-aachen.de
+
+# `20.62.81.57` is a dynamic generated IP retrieved using command `kubectl get service -n mirror  mirror-rsyncd`
+mirrorbits add -http https://mirror.azure.jenkins.io/ -rsync rsync://20.62.81.57/jenkins/ -admin-name "Jenkins Infrastructure" -admin-email "jenkinsci-infra@googlegroups.com" mirror.azure.jenkins.io
 ```
 
 ## Links

--- a/charts/mirrorbits/README.md
+++ b/charts/mirrorbits/README.md
@@ -83,6 +83,7 @@ mirrorbits add -http https://mirror.gruenehoelle.nl/jenkins/ -rsync rsync://esme
 mirrorbits add -http https://ftp.halifax.rwth-aachen.de/jenkins/ -rsync rsync://ftp.halifax.rwth-aachen.de/jenkins/ -ftp ftp://ftp.halifax.rwth-aachen.de/jenkins/ -admin-name "ftp@halifax.rwth-aachen.de" -admin-email "ftp@halifax.rwth-aachen.de" rwth-aachen.de
 
 # `20.62.81.57` is a dynamic generated IP retrieved using command `kubectl get service -n mirror  mirror-rsyncd`
+# `20.62.81.57` can be replaced by `mirror-rsyncd.mirror` if on the same kubernetes cluster
 mirrorbits add -http https://mirror.azure.jenkins.io/ -rsync rsync://20.62.81.57/jenkins/ -admin-name "Jenkins Infrastructure" -admin-email "jenkinsci-infra@googlegroups.com" mirror.azure.jenkins.io
 ```
 


### PR DESCRIPTION
Based on the recent work done on adding a read-only rsync server to our mirror chart.
azure.mirror.jenkins.io is now ready to be added to get.jenkins.io.
This PR is here to document that manual step that I run.