### PR TITLE
Use maven repository to get latest jenkins weekly release

### DIFF
--- a/updateCli/updateCli.d/jenkins-weekly-jdk11.tpl
+++ b/updateCli/updateCli.d/jenkins-weekly-jdk11.tpl
@@ -1,16 +1,13 @@
 source:
   name: "Retrieve latest jenkins weekly version"
-  kind: githubRelease
+  kind: maven
   postfix: "-jdk11"
-  replaces:
-    - from: "jenkins-"
-      to: ""
   spec:
-    owner: "jenkinsci"
-    repository: "jenkins"
-    token: "{{ requiredEnv .github.token }}"
-    username: "{{ .github.username }}"
-    version: "latest"
+    owner: "maven"
+    url: "repo.jenkins-ci.org"
+    repository: "releases"
+    groupID: "org.jenkins-ci.main"
+    artifactID: "jenkins-war"
 conditions:
   docker:
     name: "Test jenkins/jenkins docker image tag"


### PR DESCRIPTION
It's not possible to automatically differentiate a weekly and a stable release from the latest GitHub release.
While it was useful to get the GitHub release changelog, switching back to the maven repository is more reliable

-> https://github.com/jenkinsci/jenkins/releases
