### PR TITLE
Fix build strategy to allow branch and trusted PRs for Docker Builds'GH org scanning for infra.ci

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -208,9 +208,18 @@ jenkins:
                   }
 
                   buildStrategies {
-                    buildTags {
-                      atLeastDays("0")
-                      atMostDays("7")
+                    buildAnyBranches {
+                      strategies {
+                        buildChangeRequests {
+                          ignoreTargetOnlyChanges(true)
+                          ignoreUntrustedChanges(true)
+                        }
+                        buildRegularBranches()
+                        buildTags {
+                          atLeastDays("0")
+                          atMostDays("7")
+                        }
+                      }
                     }
                   }
 


### PR DESCRIPTION

#### What this PR does / why we need it:

The PR #740 introduces a build strategy setup to allow tag triggered build (and not only "tag discovery").

But we forgot to add the "normal branch" and "trusted PRs" branch as part of this build strategy, which resulted in Jenkins picking up the changes, but not starting any build, with the message `No automatic build triggered for xxx` in the Multi-Branch Scanning logs.

