### PR TITLE
Specify jenkins_secrets

### DIFF
--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -7,6 +7,15 @@ jenkins:
   persistence:
     enabled: true
     size: 50Gi
+    volumes:
+      - name: jenkins-secrets
+        secret:
+          secretName: jenkins-secrets
+    mounts:
+      - name: jenkins-secrets
+        mountPath: /var/jenkins_secrets
+        readOnly: true
+
   controller:
     testEnabled: false
     image: jenkins/jenkins

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -17,6 +17,13 @@ jenkins:
         readOnly: true
 
   controller:
+    probes:
+      startupProbe:
+        initialDelaySeconds: 120
+      livenessProbe:
+        initialDelaySeconds: 120
+      readinessProbe:
+        initialDelaySeconds: 120
     testEnabled: false
     image: jenkins/jenkins
     tag: 2.276-jdk11


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

With the latest helm chart update, the k8s secret is not mounted anymore.
This configure ensure that secrets are available in the directory /var/jenkins_secrets

This pull request affects two services

1. release.ci.jenkins.io
2. infra.ci.jenkins.io

. 
