### PR TITLE
Add X-Frame-Options DENY to stop the pestering

### DIFF
--- a/charts/jenkinsio/templates/nginx-configmap.yaml
+++ b/charts/jenkinsio/templates/nginx-configmap.yaml
@@ -30,6 +30,8 @@ data:
             rewrite ^/$ https://www.jenkins.io/$lang$1;
           }   
       }
+      
+      add_header X-Frame-Options "DENY";
 
       location ~* \.(?:css|js|woff|eot|svg|ttf|otf|png|gif|jpe?g) {
         expires 2d;


### PR DESCRIPTION
https://infosec.mozilla.org/guidelines/web_security#x-frame-options

Although the site doesn't use iframes or have accounts, various security scanners and their associated operators continue to complain about this.

#### Is this a new chart
- [ ] `CODEOWNERS` is updated
- [ ] If secrets are needed, `.sops.yaml` must be updated with appropriated public gpg key ID, and full public gpg key must be provided to @olblak

#### What this PR does / why we need it:

Adds the X-Frame-Options: DENY header by default to nginx pages. Various script kiddies continue to spam the Jenkins Security Team about this, and it's harmless to enable.

#### Which issue this PR fixes

  - fixes # [INFRA-XXXX](https://issues.jenkins-ci.org/projects/INFRA/issues/INFRA-XXXX)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@daniel-beck 