### PR TITLE
✨ Execute the updateCli's pipeline steps only when the pipeline is triggered by the daily cron routine

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -40,7 +40,13 @@ pipeline {
       }
     }
     stage('Check Configuration Update') {
-      when { branch 'master' }
+      when {
+        allOf {
+          branch 'master'
+          // Only run updateCli's tasks when the pipeline is triggered by the "cron" routine
+          triggeredBy 'TimerTrigger'
+        }
+      }
       environment {
         UPDATECLI_GITHUB_TOKEN  = credentials('updatecli-github-token')
       }
@@ -51,7 +57,13 @@ pipeline {
       }
     }
     stage('Apply Configuration Update') {
-      when { branch 'master' }
+      when {
+        allOf {
+          branch 'master'
+          // Only run updateCli's tasks when the pipeline is triggered by the "cron" routine
+          triggeredBy 'TimerTrigger'
+        }
+      }
       environment {
         UPDATECLI_GITHUB_TOKEN  = credentials('updatecli-github-token')
       }


### PR DESCRIPTION
As per https://www.jenkins.io/doc/book/pipeline/syntax/#when, the goal is to NOT fail the pipeline when we need to apply configuration from helmfile/values to the cluster.

The idea of this PR is to make sure that updateCli only runs on the daily routine.

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>