### PR TITLE
Fix updatecli mirrorbits configuration

### DIFF
--- a/updateCli/updateCli.d/docker-mirrorbits.tpl
+++ b/updateCli/updateCli.d/docker-mirrorbits.tpl
@@ -16,7 +16,6 @@ conditions:
     kind: dockerImage
     spec:
       image: "jenkinsciinfra/mirrorbits"
-      tag: "latest"
   defaultCiDockerImage:
     name: "Test if mirrorbits docker image is set to jenkinsciinfra/mirrorbits"
     kind: yaml


### PR DESCRIPTION
In the current state it checks for the image jenkinsciinfra/mirrorbits:latest instead of jenkinsciinfra/mirrorbits:<version_retrieved_from_source>