### PR TITLE
chore: switch infra.ci to use jenkinsciinfra/jenkins-weekly image

### DIFF
--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -24,8 +24,8 @@ jenkins:
       readinessProbe:
         initialDelaySeconds: 120
     testEnabled: false
-    image: jenkins/jenkins
-    tag: 2.286-jdk11
+    image: jenkinsciinfra/jenkins-weekly
+    tag: 0.0.7-2.286
     ingress:
       apiVersion: networking.k8s.io/v1beta1
     runAsUser: 1000

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -465,11 +465,17 @@ jenkins:
               globalMatrix:
                 permissions:
                   - "Overall/Administer:admins"
+<<<<<<< HEAD
                   - "Overall/SystemRead:authenticated"
                   - "Overall/Read:authenticated"
                   - "Job/Read:authenticated"
                   - "Job/Build:authenticated"
                   - "Job/ExtendedRead:authenticated"
+                  - "Overall/SystemRead:all"
+                  - "Overall/Read:all"
+                  - "Job/Read:all"
+                  - "Job/Build:all"
+                  - "Job/ExtendedRead:all"
         system-settings: |
           jenkins:
             disabledAdministrativeMonitors:
@@ -485,6 +491,8 @@ jenkins:
           - name: SLEEP_TIME
             # Time in seconds between two polls
             value: "60"
+    overwritePlugins: false
+    installPlugins: false
     ingress:
       enabled: true
       hostName: infra.ci.jenkins.io

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -465,17 +465,11 @@ jenkins:
               globalMatrix:
                 permissions:
                   - "Overall/Administer:admins"
-<<<<<<< HEAD
                   - "Overall/SystemRead:authenticated"
                   - "Overall/Read:authenticated"
                   - "Job/Read:authenticated"
                   - "Job/Build:authenticated"
                   - "Job/ExtendedRead:authenticated"
-                  - "Overall/SystemRead:all"
-                  - "Overall/Read:all"
-                  - "Job/Read:all"
-                  - "Job/Build:all"
-                  - "Job/ExtendedRead:all"
         system-settings: |
           jenkins:
             disabledAdministrativeMonitors:

--- a/updateCli/updateCli.d/jenkins-weekly-jdk11.tpl
+++ b/updateCli/updateCli.d/jenkins-weekly-jdk11.tpl
@@ -2,24 +2,23 @@ title: "Bump jenkins weekly version"
 pipelineID: jenkinsweeklyjdk11
 sources:
   default:
-    name: "Get Jenkins latest weekly version"
-    kind: jenkins
-    transformers:
-      - addSuffix: "-jdk11"
+    name: "Get latest jenkins-weekly version"
+    kind: githubRelease
     spec:
-      release: weekly
-      github:
-        username: "{{ .github.username }}"
-        token: "{{ requiredEnv .github.token }}"
+      name: Get jenkins-infra/docker-jenkins-weekly latest version
+      owner: "jenkins-infra"
+      repository: "docker-jenkins-weekly"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
 conditions:
   docker:
-    name: "Test jenkins/jenkins:<latest_version>-jdk11 docker image tag"
+    name: "Test jenkinsciinfra/jenkins-weekly:<latest_version> docker image tag"
     kind: dockerImage
     spec:
-      image: "jenkins/jenkins"
+      image: "jenkinscinfra/jenkins-weekly"
 targets:
   imageTag:
-    name: "Update jenkins/jenkins docker image tag"
+    name: "Update jenkinsciinfra/jenkins-weekly docker image tag"
     kind: yaml
     spec:
       file: "charts/jenkins/values.yaml"


### PR DESCRIPTION
This PR switches infra.ci to use the prebuilt docker image for jenkins (including all plugins) that is defined at: https://github.com/jenkins-infra/docker-jenkins-weekly