### PR TITLE
[INFRA-2891] Add the Terraform's AWS API keys credentials to infra.ci.jenkins.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you can access the secrets, you have to set up the local `./secrets` folder f
 git clone https://github.com/jenkins-infra/charts-secrets.git ./secrets
 ```
 
-Then, you can edit a secret by usingh the `sops ./secrets/.../<your yaml file>` command.
+Then, you can edit a secret by using the `sops ./secrets/.../<your yaml file>` command.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -24,17 +24,21 @@ This project contains three main folders:
 ## Secrets
 
 Secrets are encrypted with [sops](https://github.com/mozilla/sops) and a default configuration is defined in `.sops.yaml`
-Currently there are two keys, one GPG key  and a second one in an azure key vault and accessible from Kubernetes clusters.
+Currently there are two kinds of encryption keys: a GPG key and an Azure Key-Vault (accessible from Kubernetes clusters).
 
-In order to edit a secret, just run `sops <your yaml file>`
+All secrets are expected to be found in the `./secrets` folder which is absent (gitignored) by default.
+
+If you can access the secrets, you have to set up the local `./secrets` folder from the (private) repository [jenkins-infra/charts-secrets](https://github.com/jenkins-infra/charts-secrets.git) with the following command:
+
+```bash
+git clone https://github.com/jenkins-infra/charts-secrets.git ./secrets
+```
+
+Then, you can edit a secret by usingh the `sops ./secrets/.../<your yaml file>` command.
 
 ## Docker
 
 This folder defines a custom Dockerfile in order to build a custom image to orchestrate our clusters
-
-## Rules
-
-* Secrets are define in `secrets.yaml` file and always encrypted
 
 ## Remarks
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Sign Your Work
 Any issues can be reported on our [ticket system](https://issues.jenkins-ci.org/projects/INFRA/)
 
 ## Repository Structure
+
 This project contains three main folders:
 
 * `helmfile.d`: This folder contains [Helmfile](https://github.com/roboll/helmfile)
@@ -21,18 +22,22 @@ This project contains three main folders:
 * `config`: The configuration specific our environments.
 
 ## Secrets
+
 Secrets are encrypted with [sops](https://github.com/mozilla/sops) and a default configuration is defined in `.sops.yaml`
 Currently there are two keys, one GPG key  and a second one in an azure key vault and accessible from Kubernetes clusters.
 
 In order to edit a secret, just run `sops <your yaml file>`
 
 ## Docker
+
 This folder defines a custom Dockerfile in order to build a custom image to orchestrate our clusters
 
 ## Rules
+
 * Secrets are define in `secrets.yaml` file and always encrypted
 
 ## Remarks
+
 * When deploying nexus, the postStart strict hang from time to time and we have to manually execute while containers are in creating mode
 ```kubectl exec -i -t -c nexus default-release-nexus-0 export PASSWORD=`cat /nexus-data/admin.password`; /opt/sonatype/nexus/postStart.sh```
 
@@ -41,10 +46,9 @@ This folder defines a custom Dockerfile in order to build a custom image to orch
 * If RBAC is enabled on the cluster, before being able to use helm, we need to create a service acccount for helm with the right cluster role binding.
 we can run following command: ```kubectl apply -f helm/rbac.yaml```
 
-
 ## Minikube
 
-```
+```bash
 minikube start --kubernetes-version v1.15.11
 minikube addons enable ingress
 helm install stable/nginx-ingress nginx-ingress, we can't install the ingress defined in this repository for testing servers
@@ -54,6 +58,7 @@ kubectl get secrets -n release  default-release-jenkins -o json
 ```
 
 ## Links
+
 * [Helmfile](https://github.com/roboll/helmfile)
 * [Helm Charts](https://github.com/helm/charts)
 * [Sops](https://github.com/mozilla/sops)

--- a/REVIEW_GUIDELINES.md
+++ b/REVIEW_GUIDELINES.md
@@ -8,7 +8,6 @@ The process to get a pull request merged is fairly simple. all required tests ne
 
 The charts repository uses the CODEOWNERS files to provide merge access. If a chart has an CODEOWNERS file, an approver listed in that file can approve the pull request. If the chart does not have an CODEOWNERS file, an approver in the OWNERS file at the root of the repository can approve the pull request.
 
-
 ## Immutability
 
 Chart releases must be immutable. Any change to a chart warrants a chart version bump even if it is only changed to the documentation.
@@ -38,6 +37,7 @@ The `Chart.yaml` should be as complete as possible. The following fields are man
 ## Names and Labels
 
 ### Metadata
+
 Resources and labels should follow some conventions. The standard resource metadata (`metadata.labels` and `spec.template.metadata.labels`) should be this:
 
 ```yaml
@@ -73,14 +73,14 @@ The chart label string contains the version, so if it is specified, whenever the
 
 ##### For Deployments, StatefulSets, DaemonSets apps/v1beta1 or extensions/v1beta1
 
-- If it does not specify `spec.selector.matchLabels`, set it
-- Remove `helm.sh/chart` label in `spec.selector.matchLabels` if it exists
-- Bump patch version of the Chart
+* If it does not specify `spec.selector.matchLabels`, set it
+* Remove `helm.sh/chart` label in `spec.selector.matchLabels` if it exists
+* Bump patch version of the Chart
 
 ##### For Deployments, StatefulSets, DaemonSets >=apps/v1beta2
 
-- Remove `helm.sh/chart` label in `spec.selector.matchLabels` if it exists
-- Bump major version of the Chart as it is a breaking change
+* Remove `helm.sh/chart` label in `spec.selector.matchLabels` if it exists
+* Bump major version of the Chart as it is a breaking change
 
 ### Service Selectors
 
@@ -315,7 +315,7 @@ spec:
 
 * Example prepend logic for getting an application URL in NOTES.txt:
 
-```
+```gotpl
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -84,6 +84,26 @@ jenkins:
                       id: "algolia-plugins-write-key"
                       secret: "${ALGOLIA_WRITE_KEY}"
                       description: Algolia credentials to write data for plugin site
+                  - string:
+                      scope: GLOBAL
+                      id: "ci-terraform-access-key"
+                      secret: "${CI_TERRAFORM_AWS_ACCESS_KEY_ID}"
+                      description: AWS access key id for the account 'ci-terraform'
+                  - string:
+                      scope: GLOBAL
+                      id: "ci-terraform-secret-key"
+                      secret: "${CI_TERRAFORM_AWS_SECRET_ACCESS_KEY}"
+                      description: AWS secret key for the account 'ci-terraform'
+                  - string:
+                      scope: GLOBAL
+                      id: "production-terraform-access-key"
+                      secret: "${PRODUCTION_TERRAFORM_AWS_ACCESS_KEY_ID}"
+                      description: AWS access key id for the account 'production-terraform'
+                  - string:
+                      scope: GLOBAL
+                      id: "production-terraform-secret-key"
+                      secret: "${PRODUCTION_TERRAFORM_AWS_SECRET_ACCESS_KEY}"
+                      description: AWS secret key for the account 'production-terraform'
         k8s-settings: |
           jenkins:
             clouds:


### PR DESCRIPTION
This PR introduces the following changes:

- Add 4 new credentials to the Jenkins controller at <https://infra.ci.jenkins.io> to provide AWS API keys for terraform usage
- A bit of documentation update along the way