### PR TITLE
Fine tune the LDAP plugins connection's pooling 

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -389,6 +389,13 @@ jenkins:
                     managerDN: "${LDAP_MANAGER_DN}"
                     managerPasswordSecret: "${LDAP_MANAGER_PASSWORD}"
                     userSearch: cn={0}
+                    environmentProperties:
+                      - name: "com.sun.jndi.ldap.connect.timeout"
+                        value: "20000"
+                      - name: "com.sun.jndi.ldap.read.timeout"
+                        value: "20000"
+                      - name: "com.sun.jndi.ldap.connect.pool"
+                        value: "false"
                 cache:
                   size: 100
                   ttl: 300


### PR DESCRIPTION
The goal of this PR is leverage the HTTP/504 error on infra.ci, during the user loggin phase, that are reported as "read timeout while connecting to LDAP".

These settings come from the following pages:

- https://support.cloudbees.com/hc/en-us/articles/235438387-Cannot-make-my-LDAP-configuration-to-work
- https://downey.io/blog/kubernetes-ephemeral-debug-container-tcpdump/

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>