### PR TITLE
Fix/traefik: public ingress + private ingress

### DIFF
--- a/helmfile.d/traefik.yaml
+++ b/helmfile.d/traefik.yaml
@@ -17,6 +17,7 @@ releases:
       - service:
           spec:
             externalTrafficPolicy: Local
+            # If the loadbalancer creation fails to use this IP, diagnose with "kubectl describe svc -n public-traefik public-traefik" (99% it's related to a different resource group between the public IP object and the LB)
             loadBalancerIP: 20.65.25.172
           annotations:
             service.beta.kubernetes.io/azure-load-balancer-internal: false

--- a/helmfile.d/traefik.yaml
+++ b/helmfile.d/traefik.yaml
@@ -17,13 +17,13 @@ releases:
       - service:
           spec:
             externalTrafficPolicy: Local
+            loadBalancerIP: 20.65.25.172
           annotations:
             service.beta.kubernetes.io/azure-load-balancer-internal: false
             service.beta.kubernetes.io/azure-load-balancer-internal-subnet: app-tier
             service.beta.kubernetes.io/azure-load-balancer-resource-group: prodpublick8s
             # prometheus.io/scrape: "true" -- currently not supported. https://github.com/traefik/traefik-helm-chart/issues/156#issuecomment-624523750
             # prometheus.io/port: "10254"
-            loadBalancerIP: 20.65.25.172
   - name: private-traefik
     chart: traefik/traefik
     namespace: private-traefik

--- a/helmfile.d/traefik.yaml
+++ b/helmfile.d/traefik.yaml
@@ -26,23 +26,23 @@ releases:
             # prometheus.io/scrape: "true" -- currently not supported. https://github.com/traefik/traefik-helm-chart/issues/156#issuecomment-624523750
             # prometheus.io/port: "10254"
 
-  # - name: private-traefik
-  #   chart: traefik/traefik
-  #   namespace: private-traefik
-  #   version: 9.14.3
-  #   wait: true
-  #   timeout: 300
-  #   atomic: true
-  #   values:
-  #     - "../config/default/traefik.yaml"
-  #     - additionalArguments:
-  #         - "--providers.kubernetescrd.ingressclass=traefik"
-  #         - "--providers.kubernetesingress.ingressclass=traefik"
-  #     - service:
-  #         spec:
-  #           externalTrafficPolicy: Local
-  #         annotations:
-  #           service.beta.kubernetes.io/azure-load-balancer-internal: true
-  #           service.beta.kubernetes.io/azure-load-balancer-internal-subnet: data-tier
-  #           # prometheus.io/scrape: "true" -- currently not supported. https://github.com/traefik/traefik-helm-chart/issues/156#issuecomment-624523750
-  #           # prometheus.io/port: "10254"
+  - name: private-traefik
+    chart: traefik/traefik
+    namespace: private-traefik
+    version: 9.14.3
+    wait: true
+    timeout: 300
+    atomic: true
+    values:
+      - "../config/default/traefik.yaml"
+      - additionalArguments:
+          - "--providers.kubernetescrd.ingressclass=traefik"
+          - "--providers.kubernetesingress.ingressclass=traefik"
+      - service:
+          spec:
+            externalTrafficPolicy: Local
+          annotations:
+            service.beta.kubernetes.io/azure-load-balancer-internal: true
+            service.beta.kubernetes.io/azure-load-balancer-internal-subnet: data-tier
+            # prometheus.io/scrape: "true" -- currently not supported. https://github.com/traefik/traefik-helm-chart/issues/156#issuecomment-624523750
+            # prometheus.io/port: "10254"

--- a/helmfile.d/traefik.yaml
+++ b/helmfile.d/traefik.yaml
@@ -24,23 +24,24 @@ releases:
             service.beta.kubernetes.io/azure-load-balancer-resource-group: prodpublick8s
             # prometheus.io/scrape: "true" -- currently not supported. https://github.com/traefik/traefik-helm-chart/issues/156#issuecomment-624523750
             # prometheus.io/port: "10254"
-  - name: private-traefik
-    chart: traefik/traefik
-    namespace: private-traefik
-    version: 9.14.3
-    wait: true
-    timeout: 300
-    atomic: true
-    values:
-      - "../config/default/traefik.yaml"
-      - additionalArguments:
-          - "--providers.kubernetescrd.ingressclass=traefik"
-          - "--providers.kubernetesingress.ingressclass=traefik"
-      - service:
-          spec:
-            externalTrafficPolicy: Local
-          annotations:
-            service.beta.kubernetes.io/azure-load-balancer-internal: true
-            service.beta.kubernetes.io/azure-load-balancer-internal-subnet: data-tier
-            # prometheus.io/scrape: "true" -- currently not supported. https://github.com/traefik/traefik-helm-chart/issues/156#issuecomment-624523750
-            # prometheus.io/port: "10254"
+
+  # - name: private-traefik
+  #   chart: traefik/traefik
+  #   namespace: private-traefik
+  #   version: 9.14.3
+  #   wait: true
+  #   timeout: 300
+  #   atomic: true
+  #   values:
+  #     - "../config/default/traefik.yaml"
+  #     - additionalArguments:
+  #         - "--providers.kubernetescrd.ingressclass=traefik"
+  #         - "--providers.kubernetesingress.ingressclass=traefik"
+  #     - service:
+  #         spec:
+  #           externalTrafficPolicy: Local
+  #         annotations:
+  #           service.beta.kubernetes.io/azure-load-balancer-internal: true
+  #           service.beta.kubernetes.io/azure-load-balancer-internal-subnet: data-tier
+  #           # prometheus.io/scrape: "true" -- currently not supported. https://github.com/traefik/traefik-helm-chart/issues/156#issuecomment-624523750
+  #           # prometheus.io/port: "10254"

--- a/helmfile.d/traefik.yaml
+++ b/helmfile.d/traefik.yaml
@@ -4,7 +4,7 @@ repositories:
 releases:
   - name: public-traefik
     chart: traefik/traefik
-    namespace: kube-system
+    namespace: public-traefik
     version: 9.14.3
     wait: true
     timeout: 300
@@ -26,7 +26,7 @@ releases:
             loadBalancerIP: 20.65.25.172
   - name: private-traefik
     chart: traefik/traefik
-    namespace: kube-system
+    namespace: private-traefik
     version: 9.14.3
     wait: true
     timeout: 300


### PR DESCRIPTION
This PR follows up https://github.com/jenkins-infra/charts/pull/867.

The goal is to finish the Traefik Ingress installation for the public part. Some steps are run manually to escape the "feedback loop hell", but the goal is to have the charts and its setup ready to go once boostraped.

It introduces the following changes:

* Each traefik ingress is now installed in its own namespace instead of `kube-system` (why: improve isolation)
* Fix on the public load balancer setup to specify the correct IP
