### PR TITLE
Chore: make the bot comment about diff to be collapsed to ease reviews

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -101,7 +101,7 @@ pipeline {
         container('helmfile'){
           script {
             def diff = sh(script:'helmfile --no-color -f clusters/publick8s.yaml diff --suppress-secrets --skip-deps', returnStdout: true).trim()
-            pullRequest.comment('```\n' + diff)
+            pullRequest.comment('<details><summary>Helmfile Diff</summary>\n\n```\n' + diff + '\n```\n\n</details>') // In GitHub flavored markdown, and empty line is required around the code block triple backticks
           }
         }
       }


### PR DESCRIPTION
Reference: https://github.com/jenkins-infra/charts/pull/882#issuecomment-784291726  (and idea from @jglick)

This PR makes the comment, from the bot showing the helmfile diffs in PRs, collapsed by default.