### PR TITLE
Infra-ci: Enable CloudBees Health Advisor plugin

### DIFF
--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -67,6 +67,7 @@ jenkins:
       - configuration-as-code
       - credentials
       - credentials-binding
+      - cloudbees-jenkins-advisor
       - extended-read-permission
       - git
       - git-client

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -399,6 +399,23 @@ jenkins:
                 cache:
                   size: 100
                   ttl: 300
+        advisor-settings: |
+          jenkins:
+            disabledAdministrativeMonitors:
+              - com.cloudbees.jenkins.plugins.advisor.Reminder
+          advisor:
+            acceptToS: true
+            ccs:
+            - "damien.duportal@gmail.com"
+            email: "jenkins@oblak.com"
+            excludedComponents:
+              - "ItemsContent"
+              - "GCLogs"
+              - "Agents"
+              - "RootCAs"
+              - "SlaveLogs"
+              - "HeapUsageHistogram"
+            nagDisabled: true
         pipeline-library: |
           unclassified:
             globalLibraries:


### PR DESCRIPTION
This PR introduces the following changes:

* Install the plugin [CloudBees Health Advisor](https://plugins.jenkins.io/cloudbees-jenkins-advisor/)
* Configure the plugin on Infra.ci to obtain feedback on the instance configuration
* Disable the administrative monitor  of the plugin, to avoid annoying message if it is not configured

The rationale behind using the plugin is to start analysis of the JVM configuration for infra.ci, in relation to the LDAP issues.