### PR TITLE
Fix traefik ingresses services annotations

### DIFF
--- a/helmfile.d/traefik.yaml
+++ b/helmfile.d/traefik.yaml
@@ -20,7 +20,7 @@ releases:
             # If the loadbalancer creation fails to use this IP, diagnose with "kubectl describe svc -n public-traefik public-traefik" (99% it's related to a different resource group between the public IP object and the LB)
             loadBalancerIP: 20.65.25.172
           annotations:
-            service.beta.kubernetes.io/azure-load-balancer-internal: false
+            service.beta.kubernetes.io/azure-load-balancer-internal: "false"
             service.beta.kubernetes.io/azure-load-balancer-internal-subnet: app-tier
             service.beta.kubernetes.io/azure-load-balancer-resource-group: prodpublick8s
             # prometheus.io/scrape: "true" -- currently not supported. https://github.com/traefik/traefik-helm-chart/issues/156#issuecomment-624523750
@@ -42,7 +42,7 @@ releases:
           spec:
             externalTrafficPolicy: Local
           annotations:
-            service.beta.kubernetes.io/azure-load-balancer-internal: true
+            service.beta.kubernetes.io/azure-load-balancer-internal: "true"
             service.beta.kubernetes.io/azure-load-balancer-internal-subnet: data-tier
             # prometheus.io/scrape: "true" -- currently not supported. https://github.com/traefik/traefik-helm-chart/issues/156#issuecomment-624523750
             # prometheus.io/port: "10254"


### PR DESCRIPTION
This PR follows up #903 and #867 .

The service annotations used for the traefik ingresses (both private and public) were invalid: if a string is not used for `service.beta.kubernetes.io/azure-load-balancer-internal` (we were using a boolean), then all the other annotations of kind `service.beta.kubernetes.io/azure-load-balancer-*` are ignored.

It resulted in:
- The Public IP for the `public-traefik` LB service was not associated to the correct resource group (was: `mc_prodpublick
8s_prodpublick8s_eastus2` while it should be `publick8s`)
- The LB service for `private-traefik` is not in the expected tiers, neither it is private