### PR TITLE
Tune JVM for infra.ci: resources and JAVA_OPTS

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -101,7 +101,7 @@ pipeline {
         container('helmfile'){
           script {
             def diff = sh(script:'helmfile --no-color -f clusters/publick8s.yaml diff --suppress-secrets --skip-deps', returnStdout: true).trim()
-            pullRequest.comment('<details><summary>Helmfile Diff</summary>\n\n```\n' + diff + '\n```\n\n</details>') // In GitHub flavored markdown, and empty line is required around the code block triple backticks
+            pullRequest.comment('<details><summary>Helmfile Diff</summary>\n\n```diff\n' + diff + '\n```\n\n</details>') // In GitHub flavored markdown, and empty line is required around the code block triple backticks
           }
         }
       }

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -448,6 +448,10 @@ jenkins:
                   - "Job/Read:all"
                   - "Job/Build:all"
                   - "Job/ExtendedRead:all"
+        system-settings: |
+          jenkins:
+            disabledAdministrativeMonitors:
+              - "jenkins.security.QueueItemAuthenticatorMonitor"
     ingress:
       enabled: true
       hostName: infra.ci.jenkins.io

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -9,7 +9,14 @@ jenkins:
       namespaceLabels:
         name: "jenkins-infra"
   controller:
-    javaOpts: "-XshowSettings:vm -XX:+AlwaysPreTouch -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC"
+    resources:
+      limits:
+        cpu: "2"
+        memory: "4Gi"
+      requests:
+        cpu: "2"
+        memory: "4Gi"
+    javaOpts: "-XshowSettings:vm -XX:+AlwaysPreTouch -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:MaxRAM=4g"
     JCasC:
       enabled: true
       defaultConfig: false

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -9,6 +9,7 @@ jenkins:
       namespaceLabels:
         name: "jenkins-infra"
   controller:
+    javaOpts: "-XshowSettings:vm -XX:+AlwaysPreTouch -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC"
     JCasC:
       enabled: true
       defaultConfig: false


### PR DESCRIPTION
The goal of this PR is to improve the resources usage and performance of infra.ci:

- After #908 , we received a first report from Health Advisor that points to <https://support.cloudbees.com/hc/en-us/articles/204859670-Java-Heap-settings-best-practice>. This PR adds the proposed java opts flags adapted for the JDK 11

<img width="570" alt="Capture d’écran 2021-03-02 à 09 49 52" src="https://user-images.githubusercontent.com/1522731/109622669-a7e52a80-7b3c-11eb-98f6-28d2fd3b55b8.png">

- Set the initial resources requested for Jenkins to the same as the limit to ensure that the JVM has enough resources at startup to ensure a fast and efficient startup. The goal is to start from there and then improve monitoring of the JVM usage to ensure that we can add jobs efficiently, restart the instance fast, and diagnose the "LDAP" timeout issues.

- After #908 where an administrative monitor is dismissed as code, this PRs adds a new system config to dismiss another monitor which was back to the menu

- Minor comment from https://github.com/jenkins-infra/charts/pull/907#discussion_r584851396