### PR TITLE
[INFRA-2891] Infra CI: add S3 terraform backend configs for aws as credentials 

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -102,6 +102,11 @@ jenkins:
                       id: "ci-terraform-secret-key"
                       secret: "${CI_TERRAFORM_AWS_SECRET_ACCESS_KEY}"
                       description: AWS secret key for the account 'ci-terraform'
+                  - file:
+                      fileName: "backend-config"
+                      id: "ci-terraform-backend-config"
+                      scope: GLOBAL
+                      secretBytes: "${CI_TERRAFORM_BACKEND_CONFIG}"
                   - string:
                       scope: GLOBAL
                       id: "production-terraform-access-key"
@@ -112,6 +117,11 @@ jenkins:
                       id: "production-terraform-secret-key"
                       secret: "${PRODUCTION_TERRAFORM_AWS_SECRET_ACCESS_KEY}"
                       description: AWS secret key for the account 'production-terraform'
+                  - file:
+                      fileName: "backend-config"
+                      id: "production-terraform-backend-config"
+                      scope: GLOBAL
+                      secretBytes: "${PRODUCTION_TERRAFORM_BACKEND_CONFIG}"
         k8s-settings: |
           jenkins:
             clouds:


### PR DESCRIPTION
Scope: states for aws (ci and production accounts).

Requires https://github.com/jenkins-infra/charts-secrets/pull/17 to be merged to allow accessing the secrets