### PR TITLE
Infra CI: Windows pods should use the same image as release.ci

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -155,7 +155,7 @@ jenkins:
                       nodeSelector: "kubernetes.io/os=windows"
                       containers:
                         - name: jnlp
-                          image: "jenkins4eval/jnlp-agent:latest-windows"
+                          image: "jenkins/inbound-agent:windowsservercore-1809"
                           resourceLimitCpu: "500m"
                           resourceLimitMemory: "512Mi"
                           resourceRequestCpu: "500m"


### PR DESCRIPTION
Signed-off-by: Damien Duportal <damien.duportal@gmail.com>