### PR TITLE
Fix/lint fail keycloak

### DIFF
--- a/config/default/keycloak.yaml
+++ b/config/default/keycloak.yaml
@@ -11,7 +11,7 @@ ingress:
       paths: [/]
   tls:
     - hosts:
-      - admin.accounts.jenkins.io
+        - admin.accounts.jenkins.io
       secretName: keycloak-cert
 
 

--- a/yamllint.config
+++ b/yamllint.config
@@ -1,8 +1,6 @@
 extends: default
 
 rules:
-  line-length:
-    max: 100
-    level: warning
+  line-length: disable
 
   document-start: disable


### PR DESCRIPTION
The lint step was failing due to an indentation issue with the keycloak config.

This PR also disable the lint rule about line length, as no one read/fix it, so it has low value and only hide the real errors.