### PR TITLE
Chore/switch ci sidecars to polling

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -463,6 +463,17 @@ jenkins:
           jenkins:
             disabledAdministrativeMonitors:
               - "jenkins.security.QueueItemAuthenticatorMonitor"
+    sidecars:
+      configAutoReload:
+        env:
+          # https://github.com/kiwigrid/k8s-sidecar#configuration-environment-variables
+          - name: METHOD
+            # Polling mode (instead of watching kube API)
+            value: "SLEEP"
+          # https://github.com/kiwigrid/k8s-sidecar#configuration-environment-variables
+          - name: SLEEP_TIME
+            # Time in seconds between two polls
+            value: "60"
     ingress:
       enabled: true
       hostName: infra.ci.jenkins.io

--- a/config/default/jenkins-release.yaml
+++ b/config/default/jenkins-release.yaml
@@ -414,7 +414,7 @@ jenkins:
                 cache:
                   size: 100
                   ttl: 300
-          advisor-settings: |
+        advisor-settings: |
           jenkins:
             disabledAdministrativeMonitors:
               - com.cloudbees.jenkins.plugins.advisor.Reminder

--- a/config/default/jenkins-release.yaml
+++ b/config/default/jenkins-release.yaml
@@ -444,6 +444,17 @@ jenkins:
           jenkins:
             disabledAdministrativeMonitors:
               - "jenkins.security.QueueItemAuthenticatorMonitor"
+    sidecars:
+      configAutoReload:
+        env:
+          # https://github.com/kiwigrid/k8s-sidecar#configuration-environment-variables
+          - name: METHOD
+            # Polling mode (instead of watching kube API)
+            value: "SLEEP"
+          # https://github.com/kiwigrid/k8s-sidecar#configuration-environment-variables
+          - name: SLEEP_TIME
+            # Time in seconds between two polls
+            value: "60"
     ingress:
       enabled: true
       hostName: release.ci.jenkins.io

--- a/helmfile.d/datadog.yaml
+++ b/helmfile.d/datadog.yaml
@@ -7,7 +7,7 @@ releases:
     chart: datadog/datadog
     version: 2.10.3
     wait: true
-    timeout: 300
+    timeout: 600
     atomic: true
     values:
       - "../config/default/datadog/datadog.yaml"


### PR DESCRIPTION
This PR introduces the following changes:

* Chore: set infra.ci and release.ci Jenkins' sidecars to polling mode instead of watching.
  - The goal is to avoid missing configmap update events.
  - Ref. https://github.com/hmcts/cnp-flux-config/pull/8674 and https://github.com/kiwigrid/k8s-sidecar/issues/85
  - Drawback: deletion of configmap is not detected with this change. It means that removing top-level entries on the JCasc value config will require a pod deletion.
* Bugfix: with #972 , I introduced an issue with the indentation of the advisor plugin configuration.
* Chore: increase the datadog chart timeout as the builds are often failing these days, while applying the datadog step