### PR TITLE
Enforce https redirection from url !=  www.jenkins.io

### DIFF
--- a/charts/jenkinsio/templates/nginx-configmap.yaml
+++ b/charts/jenkinsio/templates/nginx-configmap.yaml
@@ -16,7 +16,7 @@ data:
   
       {{- if .Values.forceJenkinsIoHost -}}
       if ( $host != 'www.jenkins.io') {
-        return 301 $scheme://www.jenkins.io$request_uri;
+        return 301 https://www.jenkins.io$request_uri;
       }
       {{- end }}
   

--- a/charts/jenkinsio/templates/zh-configmap.yaml
+++ b/charts/jenkinsio/templates/zh-configmap.yaml
@@ -12,7 +12,7 @@ data:
   
     {{- if .Values.forceJenkinsIoHost -}}
       if ( $host != 'www.jenkins.io') {
-        return 301 $scheme://www.jenkins.io/zh/$request_uri;
+        return 301 https://www.jenkins.io/zh/$request_uri;
       }
     {{- end }}
   


### PR DESCRIPTION

It's an attempt to fix the jenkins.io redirection to HTTP instead of HTTPS
This redirection is done in the Nginx container behind the k8s ingress which only accepts HTTP connection, I guess that because of that behavior $scheme is always HTTP instead of HTTPS

The downside of this approach is that we assume that www.jenkins.io is always available when we come from a different URL than www.jenkins.io

Signed-off-by: Olivier Vernin <olivier@vernin.me>