### PR TITLE
fix: set the websocketConnectionTimeout option on the correct key for infra.ci

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -19,7 +19,6 @@ jenkins:
     javaOpts: >
       -XshowSettings:vm -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:MaxRAM=4g -XX:+AlwaysPreTouch
       -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/ -XX:+UseG1GC
-    jenkinsOpts: >
       -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.websocketConnectionTimeout=60
     JCasC:
       enabled: true


### PR DESCRIPTION
It looks like that in #993 , I failed to specify the option `org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.websocketConnectionTimeout` in the correct location for infra.ci.

It was underlined by recent builds which where complaining about the value being set to the default of `30`.

The goal of this PR is to decrease the amount of failure due to this error.