### PR TITLE
chore: allow infra.ci to read secrets

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -1,6 +1,8 @@
 ---
 clusterAdminEnabled: true
 jenkins:
+  rbac:
+    readSecrets: true
   agent:
     componentName: "agent"
   networkPolicy:


### PR DESCRIPTION
This is to allow the kubernetes-credential-provider plugin to read the secrets from kubernetes