### PR TITLE
chore: enable overwrite plugins on release/infra

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -487,7 +487,6 @@ jenkins:
           - name: SLEEP_TIME
             # Time in seconds between two polls
             value: "60"
-    overwritePlugins: false
     installPlugins: false
     ingress:
       enabled: true

--- a/config/default/jenkins-release.yaml
+++ b/config/default/jenkins-release.yaml
@@ -457,7 +457,6 @@ jenkins:
           - name: SLEEP_TIME
             # Time in seconds between two polls
             value: "60"
-    overwritePlugins: false
     installPlugins: false
     ingress:
       enabled: true


### PR DESCRIPTION
This is to remove the plugin conflicts when copying plugins from the shared volume