### PR TITLE
Increase websocketConnectionTimeout for release.ci

### DIFF
--- a/config/default/jenkins-release.yaml
+++ b/config/default/jenkins-release.yaml
@@ -28,6 +28,7 @@ jenkins:
     javaOpts: >
       -XshowSettings:vm -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:MaxRAM=4g -XX:+AlwaysPreTouch
       -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/ -XX:+UseG1GC
+      -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.websocketConnectionTimeout=60
     JCasC:
       enabled: true
       defaultConfig: false


### PR DESCRIPTION
Using the default value set to 30 leads to connection tieout errors on infra.ci
Signed-off-by: Olivier Vernin <olivier@vernin.me>