### PR TITLE
Fix updatecli configuration for captain hook 

### DIFF
--- a/updateCli/updateCli.d/charts/captain-hook.tpl
+++ b/updateCli/updateCli.d/charts/captain-hook.tpl
@@ -10,6 +10,7 @@ conditions:
   chartVersion:
     name: "Test captain-hook/captain-hook Helm Chart position in helmfile"
     kind: yaml
+    sourceID: default
     spec:
       file: "helmfile.d/captain-hook.yaml"
       key: "releases[0].name"

--- a/updateCli/updateCli.d/charts/captain-hook.tpl
+++ b/updateCli/updateCli.d/charts/captain-hook.tpl
@@ -1,19 +1,14 @@
-source:
-  kind: helmChart
-  spec:
-    url: https://garethjevans.github.io/captain-hook
-    name: captain-hook
-
-
-conditions:
-  exist:
-    name: "Captain Hook Helm Chart Published on Registry"
+title: Bump Captain Hook helm chart version
+pipelineID: captainhookhelmfile
+sources:
+  default:
     kind: helmChart
     spec:
       url: https://garethjevans.github.io/captain-hook
       name: captain-hook
+conditions:
   chartVersion:
-    name: "captain-hook/captain-hook Helm Chart"
+    name: "Test captain-hook/captain-hook Helm Chart position in helmfile"
     kind: yaml
     spec:
       file: "helmfile.d/captain-hook.yaml"
@@ -32,6 +27,7 @@ conditions:
 targets:
   chartVersion:
     name: "captain-hook/captain-hook Helm Chart"
+    sourceID: default
     kind: yaml
     spec:
       file: "helmfile.d/captain-hook.yaml"


### PR DESCRIPTION
Fix updatecli configuration for captain hook to remove warning about deprecating fields