### PR TITLE
Split jenkins nginx configuration per website

### DIFF
--- a/charts/jenkinsio/templates/deployment.yaml
+++ b/charts/jenkinsio/templates/deployment.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "jenkinsio.fullname" . }}
-  labels: {{ include "jenkinsio.labels" . | nindent 4 }}
+  name: {{include "jenkinsio.fullname" .}}
+  labels: {{include "jenkinsio.labels" . | nindent 4}}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{.Values.replicaCount}}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "jenkinsio.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{include "jenkinsio.name" .}}
+      app.kubernetes.io/instance: {{.Release.Name}}
   template:
     metadata:
-      labels: {{ include "jenkinsio.labels" . | nindent 8 }}
+      labels: {{include "jenkinsio.labels" . | nindent 8}}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum }}
+        checksum/config: {{include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum}}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -25,8 +25,8 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.images.en.repository }}:{{ .Values.images.en.tag }}"
+          imagePullPolicy: {{ .Values.images.en.pullPolicy }}
           ports:
               - name: {{ include "jenkinsio.fullname" . }}
                 containerPort: 80

--- a/charts/jenkinsio/templates/zh-deployment.yaml
+++ b/charts/jenkinsio/templates/zh-deployment.yaml
@@ -7,13 +7,13 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "jenkinsio.name" . }}-zh
-      app.kubernetes.io/instance: {{ .Release.Name }}-zh
+      app.kubernetes.io/name: {{include "jenkinsio.name" .}}-zh
+      app.kubernetes.io/instance: {{.Release.Name}}-zh
   template:
     metadata:
-      labels: {{ include "zh-jenkinsio.labels" . | nindent 8 }}
+      labels: {{include "zh-jenkinsio.labels" . | nindent 8}}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/zh-configmap.yaml") . | sha256sum }}
+        checksum/config: {{include (print $.Template.BasePath "/zh-configmap.yaml") . | sha256sum}}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -25,8 +25,8 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.images.zh.repository }}:{{ .Values.images.zh.tag }}"
+          imagePullPolicy: {{ .Values.images.zh.pullPolicy }}
           ports:
               - name: {{ include "jenkinsio.fullname" . }}-zh
                 containerPort: 80

--- a/charts/jenkinsio/values.yaml
+++ b/charts/jenkinsio/values.yaml
@@ -3,17 +3,22 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
-image:
-  repository: nginx@sha256 # nginx:1.17
-  tag: 5b5f9dcffa0545d376347e3c55f92a3536ecfb69f5638616d297ee43a8363131
-  pullPolicy: Always
+images:
+  en:
+    repository: nginx@sha256  # nginx:1.17
+    tag: 5b5f9dcffa0545d376347e3c55f92a3536ecfb69f5638616d297ee43a8363131
+    pullPolicy: Always
+  zh:
+    repository: nginx@sha256  # nginx:1.17
+    tag: 5b5f9dcffa0545d376347e3c55f92a3536ecfb69f5638616d297ee43a8363131
+    pullPolicy: Always
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 service:
   type: ClusterIP
 # Please define ingress settings into environment variable
-#ingress:
+# ingress:
 #  enabled: true
 #  annotations:
 #    "cert-manager.io/cluster-issuer": "letsencrypt-prod"

--- a/updateCli/updateCli.d/nginx.tpl
+++ b/updateCli/updateCli.d/nginx.tpl
@@ -8,7 +8,7 @@ sources:
       image: "nginx"
       tag: "stable"
 conditions:
-  usJenkinsio:
+  ENJenkinsio:
     name: "Update nginx:stable docker image digest for jenkins.io"
     kind: yaml
     spec:
@@ -24,7 +24,7 @@ conditions:
         token: "{{ requiredEnv .github.token }}"
         username: "{{ .github.username }}"
         branch: "{{ .github.branch }}"
-  zhJenkinsio:
+  ZHJenkinsio:
     name: "Update nginx:stable docker image digest for jenkins.io/zh"
     kind: helmChart
     spec:
@@ -42,7 +42,7 @@ conditions:
         branch: "{{ .github.branch }}"
 
 targets:
-  usJenkinsio:
+  USJenkinsio:
     name: "Update nginx:stable docker image digest"
     kind: helmChart
     spec:
@@ -58,7 +58,7 @@ targets:
         token: "{{ requiredEnv .github.token }}"
         username: "{{ .github.username }}"
         branch: "{{ .github.branch }}"
-  zhJenkinsio:
+  ZHJenkinsio:
     name: "Update nginx:stable docker image digest"
     kind: helmChart
     spec:

--- a/updateCli/updateCli.d/nginx.tpl
+++ b/updateCli/updateCli.d/nginx.tpl
@@ -7,13 +7,63 @@ sources:
     spec:
       image: "nginx"
       tag: "stable"
+conditions:
+  usJenkinsio:
+    name: "Update nginx:stable docker image digest for jenkins.io"
+    kind: yaml
+    spec:
+      file: charts/jenkinsio
+      key: images.en.repository
+      value: nginx@sha256
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  zhJenkinsio:
+    name: "Update nginx:stable docker image digest for jenkins.io/zh"
+    kind: helmChart
+    spec:
+      file: charts/jenkinsio
+      key: images.zh.repository
+      value: nginx@sha256
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+
 targets:
-  nginx:
+  usJenkinsio:
     name: "Update nginx:stable docker image digest"
     kind: helmChart
     spec:
       name: charts/jenkinsio
-      key: image.tag
+      key: images.us.tag
+      versionIncrement: patch
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  zhJenkinsio:
+    name: "Update nginx:stable docker image digest"
+    kind: helmChart
+    spec:
+      name: charts/jenkinsio
+      key: images.zh.tag
       versionIncrement: patch
     scm:
       github:


### PR DESCRIPTION
This pull request split the jenkins.io nginx configuration in two, the goal is to prepare the land for this pull request https://github.com/jenkins-infra/jenkins.io/pull/4233 so we can update the English and Chinese docker image separately.

Signed-off-by: Olivier Vernin <olivier@vernin.me>