### PR TITLE
Revert "jenkinsio helm chart used a self-contain docker image for the default website (#1070)"

### DIFF
--- a/charts/jenkinsio/templates/deployment.yaml
+++ b/charts/jenkinsio/templates/deployment.yaml
@@ -12,6 +12,8 @@ spec:
   template:
     metadata:
       labels: {{include "jenkinsio.labels" . | nindent 8}}
+      annotations:
+        checksum/config: {{include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum}}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -43,6 +45,11 @@ spec:
                   scheme: HTTP
               initialDelaySeconds: 5
               timeoutSeconds: 5
+          volumeMounts:
+            - name: html
+              mountPath: /usr/share/nginx/html
+            - name: config
+              mountPath: /etc/nginx/conf.d
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
@@ -57,3 +64,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      volumes:
+        - name: html
+{{ toYaml .Values.htmlVolume | indent 10 }}
+        - name: config
+          configMap:
+            name: jenkinsio

--- a/charts/jenkinsio/templates/nginx-configmap.yaml
+++ b/charts/jenkinsio/templates/nginx-configmap.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jenkinsio.fullname" . }}
+  labels: {{ include "jenkinsio.labels" . | nindent 4 }}
+data:
+  default.conf: |
+    map $http_accept_language $lang {
+      default '';
+      ~^zh zh;
+    }
+
+    server {
+      listen       80;
+      server_name  localhost;
+  
+      {{- if .Values.forceJenkinsIoHost -}}
+      if ( $host != 'www.jenkins.io') {
+        return 301 https://www.jenkins.io$request_uri;
+      }
+      {{- end }}
+  
+      root   /usr/share/nginx/html;
+
+      location / {
+          index  index.html index.htm;
+          add_header Vary "Accept-Language";
+          # Language setting
+          if ($lang) {
+            rewrite ^/$ https://www.jenkins.io/$lang$1;
+          }   
+      }
+      
+      add_header X-Frame-Options "DENY";
+
+      location ~* \.(?:css|js|woff|eot|svg|ttf|otf|png|gif|jpe?g) {
+        expires 2d;
+        add_header Cache-Control "public";
+      }
+
+      location ~* \.(html|json|xml)$ {
+        expires 1h;
+        add_header Cache-Control "public";
+      }
+
+      error_page  404              /404/index.html;
+  
+      # redirect server error pages to the static page /50x.html
+      #
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+          root   /usr/share/nginx/html;
+      }
+  
+      # compatibility with old package repository locations
+      rewrite ^/redhat/(.*) https://pkg.jenkins.io/redhat/$1 permanent;
+      rewrite ^/opensuse/(.*) https://pkg.jenkins.io/opensuse/$1 permanent;
+      rewrite ^/debian/(.*) https://pkg.jenkins.io/debian/$1 permanent;
+  
+      # convenient short URLs
+      rewrite ^/issue/(.+)          https://issues.jenkins-ci.org/browse/JENKINS-$1 permanent;
+      rewrite ^/commit/core/(.+)    https://github.com/jenkinsci/jenkins/commit/$1 permanent;
+      rewrite ^/commit/(.+)/(.+)    https://github.com/jenkinsci/$1/commit/$2 permanent;
+      rewrite ^/pull/(.+)/([0-9]+)  https://github.com/jenkinsci/$1/pull/$2 permanent;
+  
+      rewrite ^/maven-site/hudson-core /maven-site/jenkins-core permanent;
+  
+      # https://issues.jenkins-ci.org/browse/INFRA-351
+      rewrite ^/maven-hpi-plugin(.*) http://jenkinsci.github.io/maven-hpi-plugin/$1 permanent;
+  
+      # Probably not needed but, rating code moved a while ago
+      rewrite ^/rate/(.*) https://rating.jenkins.io/$1 permanent;
+      rewrite ^/census/(.*) https://census.jenkins.io/$1 permanent;
+      rewrite ^/jenkins-ci.org.key$ https://pkg.jenkins.io/redhat/jenkins.io.key permanent;
+  
+      # permalinks
+      # - this one is referenced from 1.395.1 "sign post" release
+      rewrite ^/why$            https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=53608972 permanent;
+      # baked in the help file to create account on Oracle for JDK downloads
+      rewrite ^/oracleAccountSignup$    http://www.oracle.com/webapps/redirect/signon?nexturl=http://jenkins-ci.org/ permanent;
+      # to the donation page
+      rewrite ^/donate$        https://wiki.jenkins-ci.org/display/JENKINS/Donation permanent;
+      # CLA links used in the CLA forms
+      rewrite ^/license$        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document#GovernanceDocument-cla permanent;
+      rewrite ^/licenses$        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document#GovernanceDocument-cla permanent;
+      # used to advertise the project meeting
+      rewrite ^/meetings/$        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Meeting+Agenda permanent;
+      # used from friends of Jenkins plugin to link to the thank you page
+      rewrite ^/friend$        https://wiki.jenkins-ci.org/display/JENKINS/Donation permanent;
+      # used by Gradle JPI plugin to include fragment
+      rewrite ^/gradle-jpi-plugin/latest$    https://raw.github.com/jenkinsci/gradle-jpi-plugin/master/install permanent;
+      # used when encouraging people to subscribe to security advisories
+      rewrite ^/advisories$        https://wiki.jenkins-ci.org/display/JENKINS/Security+Advisories permanent;
+      # used in slides and handouts to refer to survey
+      rewrite ^/survey$        http://s.zoomerang.com/s/JenkinsSurvey permanent;
+      # used by RekeySecretAdminMonitor in Jenkins
+      rewrite ^/rekey$            https://wiki.jenkins-ci.org/display/SECURITY/Re-keying permanent;
+      # persistent Google hangout link
+      rewrite ^/hangout$        https://plus.google.com/hangouts/_/event/cjh74ltrnc8a8r2e3dbqlfnie38 permanent;
+      # .16.203.43 repo.jenkins-ci.org
+      rewrite ^/pull-request-greeting$    https://wiki.jenkins-ci.org/display/JENKINS/Pull+Request+to+Repositories permanent;
+      # Mailer plugin uses this to redirect to Javamail jenkinsio page
+      rewrite ^/javamail-properties$   https://javamail.java.net/nonav/docs/api/overview-summary.html#overview_description permanent;
+      # baked in jenkins.war 1.587 / 1.580.1
+      rewrite ^/security-144$          https://wiki.jenkins-ci.org/display/JENKINS/Slave+To+Master+Access+Control permanent;
+      # baked in 1.600 easter egg
+      rewrite ^/100k$                  https://www.jenkins.io/content/jenkins-celebration-day-february-26 permanent;
+      rewrite ^/jep/([0-9]+) https://github.com/jenkinsci/jep/blob/master/jep/$1/README.adoc permanent;
+      rewrite ^/iep/([0-9]+) https://github.com/jenkins-infra/iep/blob/master/iep/$1/README.adoc permanent;
+    }

--- a/charts/jenkinsio/values.yaml
+++ b/charts/jenkinsio/values.yaml
@@ -5,9 +5,9 @@
 replicaCount: 1
 images:
   en:
-    repository: jenkinsciinfra/jenkinsio@sha256  # latest
-    tag: 013d9c4f5d1f6e33752d4d1a5c07af64b19908391cbe95417141055e3279dfd0
-    pullPolicy: IfNotPresent
+    repository: nginx@sha256 # nginx:1.17
+    tag: 9b0fc8e09ae1abb0144ce57018fc1e13d23abd108540f135dc83c0ed661081cf
+    pullPolicy: Always
   zh:
     repository: nginx@sha256 # nginx:1.17
     tag: 9b0fc8e09ae1abb0144ce57018fc1e13d23abd108540f135dc83c0ed661081cf
@@ -49,5 +49,6 @@ resources:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+htmlVolume:
 zhHtmlVolume:
 forceJenkinsIoHost: false

--- a/config/default/jenkinsio.yaml
+++ b/config/default/jenkinsio.yaml
@@ -73,6 +73,12 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+htmlVolume:
+  azureFile:
+    secretName: jenkinsio
+    shareName: jenkinsio
+    readOnly: true
+
 zhHtmlVolume:
   azureFile:
     secretName: jenkinsio

--- a/updateCli/updateCli.d/nginx.tpl
+++ b/updateCli/updateCli.d/nginx.tpl
@@ -8,6 +8,22 @@ sources:
       image: "nginx"
       tag: "stable"
 conditions:
+  ENJenkinsio:
+    name: "Update nginx:stable docker image digest for jenkins.io"
+    kind: yaml
+    spec:
+      file: charts/jenkinsio/values.yaml
+      key: images.en.repository
+      value: nginx@sha256
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
   ZHJenkinsio:
     name: "Update nginx:stable docker image digest for jenkins.io/zh"
     kind: yaml
@@ -26,6 +42,22 @@ conditions:
         branch: "{{ .github.branch }}"
 
 targets:
+  USJenkinsio:
+    name: "Update nginx:stable docker image digest"
+    kind: helmChart
+    spec:
+      name: charts/jenkinsio
+      key: images.en.tag
+      versionIncrement: patch
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
   ZHJenkinsio:
     name: "Update nginx:stable docker image digest"
     kind: helmChart


### PR DESCRIPTION
## Revert docker image use temporarily

Need to delay the use of the docker image until we have the automation running that will apply the change to the helm chart and push that change to the central repository.

Proposal to revert has been approved by olblak in a private channel.

This reverts commit 5e8aaeaff71c39e9008332d705dbdf5648bebf4f.
