### PR TITLE
fix: remove a deprecated configuration directive in jenkins infra.ci

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -242,7 +242,6 @@ jenkins:
                       - name: "jenkins"
                         value: "infra.ci.jenkins.io"
                       type: T4gMedium
-                      useDedicatedTenancy: false
                       useEphemeralDevices: true
                     - ami: "ami-03233867ef33df3bc" # https://github.com/jenkins-infra/packer-images/blob/master/aws/windows-2019-agent.amd64.json
                       amiOwners: "200564066411"
@@ -279,7 +278,6 @@ jenkins:
                       - name: "jenkins"
                         value: "infra.ci.jenkins.io"
                       type: T3Medium
-                      useDedicatedTenancy: false
                       useEphemeralDevices: true
         jobs-settings: |
           jobs:


### PR DESCRIPTION
A breaking change was introduced by the 1.57 ec2-plugin update:
https://github.com/jenkinsci/ec2-plugin/pull/492#pullrequestreview-605360930

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>