### PR TITLE
feat: improve infra.ci jobs children cleanup

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -298,6 +298,11 @@ jenkins:
                       scriptPath('Jenkinsfile_k8s')
                     }
                   }
+                  orphanedItemStrategy {
+                    discardOldItems {
+                      daysToKeep(1) // Keep removed SCM heads/branch/PRs only for 1 day
+                    }
+                  }
                   configure { node ->
                     def traits = node / 'sources' / 'data' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
                     traits << 'org.jenkinsci.plugins.github__branch__source.BranchDiscoveryTrait' {
@@ -364,8 +369,7 @@ jenkins:
 
                   orphanedItemStrategy {
                     discardOldItems {
-                      daysToKeep(7)
-                      numToKeep(10)
+                      daysToKeep(1) // Keep removed SCM heads/branch/PRs only for 1 day
                     }
                   }
 
@@ -433,6 +437,11 @@ jenkins:
                   factory {
                     workflowBranchProjectFactory {
                       scriptPath('Jenkinsfile_k8s')
+                    }
+                  }
+                  orphanedItemStrategy {
+                    discardOldItems {
+                      daysToKeep(1) // Keep removed SCM heads/branch/PRs only for 1 day
                     }
                   }
                 }


### PR DESCRIPTION
The goal of this PR is to ensure that we do not keep the "orphan children" for multibranch pipeline jobs on infra.ci.
These childrens are GitHub branches, tags and PRs, and the current config marks them immediatly as "unused" when removed on GitHub (for instance: when a PR is merged), but the jobs are still kept and stored on the underlying filesystem.