### PR TITLE
Double mirrorbits container usage limit

### DIFF
--- a/config/default/mirrorbits.yaml
+++ b/config/default/mirrorbits.yaml
@@ -5,11 +5,11 @@ replicaCount:
 resources:
   mirrorbits:
     limits:
-      cpu: 1000m
-      memory: 1024Mi
+      cpu: 2000m
+      memory: 2048Mi
     requests:
-      cpu: 1000m
-      memory: 1024Mi
+      cpu: 2000m
+      memory: 2048Mi
   files:
     limits:
       cpu: 500m


### PR DESCRIPTION
While reviewing mirrorbits resource usage on publickk8s, I saw that the third containers were at their max capacity, because of the IO constraint on the azure file storage below, I would like to first increase the CPU/memory instead of adding more mirrorbits containers.

Signed-off-by: Olivier Vernin <olivier@vernin.me>