### PR TITLE
Bump updatecli version

### DIFF
--- a/PodTemplates.yaml
+++ b/PodTemplates.yaml
@@ -59,7 +59,7 @@ spec:
       env:
         - name: "HOME"
           value: "/home/helm"
-      image: "ghcr.io/updatecli/updatecli:v0.3.1"
+      image: "ghcr.io/updatecli/updatecli:v0.3.4"
       imagePullPolicy: "Always"
       name: "updatecli"
       resources:


### PR DESCRIPTION
I missing pr notifications

The `ghcr.io/updatecli/updatecli:v0.3.1` is missing root certificates to interact with github Api