### PR TITLE
Cleanup infra.ci's configuration

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -523,9 +523,9 @@ jenkins:
                 }
             - script: >
                 [
-                  ['jenkins-infra', 'jenkins-wiki-exporter', 'Wiki Exporter'],
-                  ['jenkinsci', 'custom-distribution-service', 'Custom Distribution Service'],
-                  ['jenkins-infra', 'incrementals-publisher', 'Incrementals Publisher'],
+                  ['jenkins-infra', 'jenkins-wiki-exporter', 'Wiki Exporter', 2021042801],
+                  ['jenkinsci', 'custom-distribution-service', 'Custom Distribution Service', 2021042802],
+                  ['jenkins-infra', 'incrementals-publisher', 'Incrementals Publisher', 2021042801],
                 ].each { config ->
                   multibranchPipelineJob(config[1]) {
                     displayName config[2]
@@ -538,6 +538,7 @@ jenkins:
                       branchSource {
                         source {
                           github {
+                            id(config[3])
                             credentialsId("github-app-infra")
                             configuredByUrl(true)
                             repositoryUrl('https://github.com/' + config[0] + '/' + config[1])

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -523,9 +523,9 @@ jenkins:
                 }
             - script: >
                 [
-                  ['jenkins-infra', 'jenkins-wiki-exporter', 'Wiki Exporter', 2021042801],
-                  ['jenkinsci', 'custom-distribution-service', 'Custom Distribution Service', 2021042802],
-                  ['jenkins-infra', 'incrementals-publisher', 'Incrementals Publisher', 2021042801],
+                  ['jenkins-infra', 'jenkins-wiki-exporter', 'Wiki Exporter', '2021042801'],
+                  ['jenkinsci', 'custom-distribution-service', 'Custom Distribution Service', '2021042802'],
+                  ['jenkins-infra', 'incrementals-publisher', 'Incrementals Publisher', '2021042801'],
                 ].each { config ->
                   multibranchPipelineJob(config[1]) {
                     displayName config[2]
@@ -548,8 +548,21 @@ jenkins:
                               gitHubBranchDiscovery {
                                 strategyId(1) // 1-only branches that are not pull requests
                               }
+                              // Only Origin Pull Request
+                              gitHubPullRequestDiscovery {
+                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                              }
                               pruneStaleBranchTrait()
                               gitHubTagDiscovery()
+                              pullRequestLabelsBlackListFilterTrait {
+                                labels('on-hold ci-skip')
+                              }
+                              headWildcardFilterWithPR {
+                                includes('main master PR-*')
+                                excludes('')
+                                tagIncludes('*')
+                                tagExcludes('')
+                              }
                             }
                           }
                           buildStrategies {
@@ -588,6 +601,19 @@ jenkins:
                     factory {
                       workflowBranchProjectFactory {
                         scriptPath('Jenkinsfile')
+                      }
+                    }
+                    orphanedItemStrategy {
+                      discardOldItems {
+                        daysToKeep(1) // Keep removed SCM heads/branch/PRs only for 1 day
+                      }
+                    }
+                    configure { node ->
+                      def traits = node / 'sources' / 'data' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
+                      // Not discovered by Job-DSL: need to be configured as raw-XML
+                      traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
+                        strategyId(1) // 1-Merging the pull request with the current target branch revision
+                        trust(class: 'org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission')
                       }
                     }
                   }

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -530,9 +530,8 @@ jenkins:
                   multibranchPipelineJob(config[1]) {
                     displayName config[2]
                     triggers {
-                      pollSCM {
-                        // poll every two hours until hooks are setup
-                        scmpoll_spec('H/2 * * * *')
+                      periodicFolderTrigger {
+                        interval('2h')
                       }
                     }
                     branchSources {


### PR DESCRIPTION
### Where

Service infra.ci.jenkins.io

### Why

- Fight against alert fatigue
- Performances
- Security

### What

- Alert fatigue: Avoid polluting logs with "SEVERE" error message which are not sever 
- Performances: ensure we don't persist data in `JENKINS_HOME` when not needed to allow faster restart of the service and less I/O usage (cost and perf)
- Security: ensure that we control "who" can execute a pipeline on infra.ci and that the configuration are state of the art and well managed to avoid config. shift

### How

This PR introduces the following changes (can be reviewed by commit):

* Switch trigger  for multibranch  from pollSCM to periodicFolderTrigger (no more SEVERE, same interval). The errors where caused by the fact that pollSCM does not apply to multibranch kind.
* Add an ID for multibranch each job to avoid conflicts with webhook or checks
* Apply the same job configuration as the github org folders: avoid untrusted users to trigger jobs, cleanup unused items after 1 day, allow to hold builds using labels, support multiple branch naming and tag based builds.



NB: expect a follow-up PR related to the other multibrancgh left alone, that should be added to the "loop" here.