### PR TITLE
(breaking) Finish infra.ci's DSL cleanup

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -297,67 +297,6 @@ jenkins:
         jobs-settings: |
           jobs:
             - script: >
-                multibranchPipelineJob('k8smgmt') {
-                  displayName "K8s Cluster Management"
-                  description "Current K8s Cluster Management"
-                  branchSources {
-                    github {
-                      id('2019081602')
-                      scanCredentialsId('github-app-infra')
-                      repoOwner('jenkins-infra')
-                      repository('charts')
-                    }
-                  }
-                  factory {
-                    workflowBranchProjectFactory {
-                      scriptPath('Jenkinsfile_k8s')
-                    }
-                  }
-                  orphanedItemStrategy {
-                    discardOldItems {
-                      daysToKeep(1) // Keep removed SCM heads/branch/PRs only for 1 day
-                    }
-                  }
-                  configure { node ->
-                    def traits = node / 'sources' / 'data' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
-                    traits << 'org.jenkinsci.plugins.github__branch__source.BranchDiscoveryTrait' {
-                      strategyId(1)
-                    }
-                    traits << 'org.jenkinsci.plugins.github__branch__source.OriginPullRequestDiscoveryTrait' {
-                      strategyId(1)
-                    }
-                    traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
-                      strategyId(1)
-                      trust(class: 'org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission')
-                    }
-                    traits << 'jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait' {
-                      includes('main master PR-*')
-                      excludes()
-                    }
-                    traits << 'org.jenkinsci.plugins.github.label.filter.PullRequestLabelsBlackListFilterTrait' {
-                      labels('on-hold ci-skip')
-                    }
-                  }
-                }
-            - script: >
-                multibranchPipelineJob('plugin-site') {
-                  displayName "Plugin Site"
-                  branchSources {
-                    github {
-                      id('2019081602')
-                      scanCredentialsId('github-app-infra')
-                      repoOwner('jenkins-infra')
-                      repository('plugin-site')
-                      includes('master')
-                    }
-                  }
-                  factory {
-                    workflowBranchProjectFactory {
-                      scriptPath('Jenkinsfile_k8s')
-                    }
-                  }
-                }
-            - script: >
                 organizationFolder('Docker Builds') {
                   description('Docker Builds')
                   displayName('Docker Builds')
@@ -523,9 +462,11 @@ jenkins:
                 }
             - script: >
                 [
-                  ['jenkins-infra', 'jenkins-wiki-exporter', 'Wiki Exporter', '2021042801'],
-                  ['jenkinsci', 'custom-distribution-service', 'Custom Distribution Service', '2021042802'],
-                  ['jenkins-infra', 'incrementals-publisher', 'Incrementals Publisher', '2021042801'],
+                  ['jenkins-infra', 'jenkins-wiki-exporter', 'Wiki Exporter', '2021042801', 'Jenkinsfile'],
+                  ['jenkinsci', 'custom-distribution-service', 'Custom Distribution Service', '2021042802', 'Jenkinsfile'],
+                  ['jenkins-infra', 'incrementals-publisher', 'Incrementals Publisher', '2021042801', 'Jenkinsfile'],
+                  ['jenkins-infra', 'charts', 'K8s Cluster Management', '2019081601', 'Jenkinsfile_k8s'],
+                  ['jenkins-infra', 'plugin-site', 'Plugin Site', '2019081603', 'Jenkinsfile_k8s'],
                 ].each { config ->
                   multibranchPipelineJob(config[1]) {
                     displayName config[2]
@@ -568,29 +509,14 @@ jenkins:
                           buildStrategies {
                             buildAnyBranches {
                               strategies {
-                                buildAllBranches {
-                                  strategies {
-                                    buildNamedBranches {
-                                      filters {
-                                        exact {
-                                          name("master")
-                                          caseSensitive(true)
-                                        }
-                                      }
-                                    }
-                                  }
+                                buildChangeRequests {
+                                  ignoreTargetOnlyChanges(true)
+                                  ignoreUntrustedChanges(true)
                                 }
-                              }
-                            }
-                            buildAnyBranches {
-                              strategies {
-                                buildAllBranches {
-                                  strategies {
-                                    buildTags {
-                                      atLeastDays '-1'
-                                      atMostDays '3'
-                                    }
-                                  }
+                                buildRegularBranches()
+                                buildTags {
+                                  atLeastDays('-1')
+                                  atMostDays('3')
                                 }
                               }
                             }
@@ -600,7 +526,7 @@ jenkins:
                     }
                     factory {
                       workflowBranchProjectFactory {
-                        scriptPath('Jenkinsfile')
+                        scriptPath(config[4])
                       }
                     }
                     orphanedItemStrategy {

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -297,166 +297,85 @@ jenkins:
         jobs-settings: |
           jobs:
             - script: >
-                organizationFolder('Docker Builds') {
-                  description('Docker Builds')
-                  displayName('Docker Builds')
-                  organizations {
-                    github {
-                      repoOwner("jenkins-infra")
-                      apiUri("https://api.github.com")
-                      credentialsId('github-app-infra')
+                [
+                  ['Docker Builds', 'jenkins-infra', 'docker-.*|^jenkins.io$'],
+                  ['Terraform Jobs', 'jenkins-infra', 'aws|datadog$'],
+                ].each { config ->
+                  organizationFolder(config[0]) {
+                    description(config[0])
+                    displayName(config[0])
+                    organizations {
+                      github {
+                        repoOwner(config[1])
+                        apiUri('https://api.github.com')
+                        credentialsId('github-app-infra')
 
-                      traits {
-                        gitHubTagDiscovery()
-                        cloneOptionTrait {
-                          extension {
-                            shallow(false)
-                            noTags(false)
-                            reference('')
-                            timeout(10)
-                            honorRefspec(true)
+                        traits {
+                          gitHubTagDiscovery()
+                          cloneOptionTrait {
+                            extension {
+                              shallow(false)
+                              noTags(false)
+                              reference('')
+                              timeout(10)
+                              honorRefspec(true)
+                            }
+                          }
+                          sourceRegexFilter {
+                            regex(config[2])
+                          }
+                          gitHubBranchDiscovery {
+                            strategyId(1) // 1-Exclude branches that are also filed as PRs
+                          }
+                          // Only Origin Pull Request
+                          gitHubPullRequestDiscovery {
+                            strategyId(1) // 1-Merging the pull request with the current target branch revision
+                          }
+                          gitHubExcludeArchivedRepositories()
+                          pullRequestLabelsBlackListFilterTrait {
+                            labels('on-hold ci-skip')
+                          }
+                          headWildcardFilterWithPR {
+                            includes('main master PR-*')
+                            excludes('')
+                            tagIncludes('*')
+                            tagExcludes('')
                           }
                         }
-                        sourceRegexFilter {
-                          regex('docker-.*|^jenkins.io$')
-                        }
-                        gitHubBranchDiscovery {
-                          strategyId(1) // 1-Exclude branches that are also filed as PRs
-                        }
-                        // Only Origin Pull Request
-                        gitHubPullRequestDiscovery {
-                          strategyId(1) // 1-Merging the pull request with the current target branch revision
-                        }
-                        gitHubExcludeArchivedRepositories()
-                        pullRequestLabelsBlackListFilterTrait {
-                          labels('on-hold ci-skip')
-                        }
-                        headWildcardFilterWithPR {
-                          includes('main master PR-*')
-                          excludes('')
-                          tagIncludes('*')
-                          tagExcludes('')
-                        }
                       }
                     }
-                  }
-
-                  orphanedItemStrategy {
-                    discardOldItems {
-                      daysToKeep(1) // Keep removed SCM heads/branch/PRs only for 1 day
-                    }
-                  }
-
-                  projectFactories {
-                    workflowMultiBranchProjectFactory {
-                      scriptPath('Jenkinsfile_k8s')
-                    }
-                  }
-
-                  buildStrategies {
-                    buildAnyBranches {
-                      strategies {
-                        buildChangeRequests {
-                          ignoreTargetOnlyChanges(true)
-                          ignoreUntrustedChanges(true)
-                        }
-                        buildRegularBranches()
-                        buildTags {
-                          atLeastDays("0")
-                          atMostDays("7")
-                        }
+                    orphanedItemStrategy {
+                      discardOldItems {
+                        daysToKeep(1) // Keep removed SCM heads/branch/PRs only for 1 day
                       }
                     }
-                  }
-
-                  configure { node ->
-                    def traits = node / navigators / 'org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator' / traits
-                    // Not discovered by Job-DSL: need to be configured as raw-XML
-                    traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
-                      strategyId(1) // 1-Merging the pull request with the current target branch revision
-                      trust(class: 'org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission')
+                    projectFactories {
+                      workflowMultiBranchProjectFactory {
+                        scriptPath('Jenkinsfile_k8s')
+                      }
                     }
-                  }
-                }
-            - script: >
-                organizationFolder('Terraform Jobs') {
-                  description('Terraform Jobs')
-                  displayName('Terraform Jobs')
-                  organizations {
-                    github {
-                      repoOwner("jenkins-infra")
-                      apiUri("https://api.github.com")
-                      credentialsId('github-app-infra')
-
-                      traits {
-                        gitHubTagDiscovery()
-                        cloneOptionTrait {
-                          extension {
-                            shallow(false)
-                            noTags(false)
-                            reference('')
-                            timeout(10)
-                            honorRefspec(true)
+                    buildStrategies {
+                      buildAnyBranches {
+                        strategies {
+                          buildChangeRequests {
+                            ignoreTargetOnlyChanges(true)
+                            ignoreUntrustedChanges(true)
+                          }
+                          buildRegularBranches()
+                          buildTags {
+                            atLeastDays('-1')
+                            atMostDays('3')
                           }
                         }
-                        sourceRegexFilter {
-                          regex('aws|datadog$')
-                        }
-                        gitHubBranchDiscovery {
-                          strategyId(1) // 1-Exclude branches that are also filed as PRs
-                        }
-                        // Only Origin Pull Request
-                        gitHubPullRequestDiscovery {
-                          strategyId(1) // 1-Merging the pull request with the current target branch revision
-                        }
-                        gitHubExcludeArchivedRepositories()
-                        pullRequestLabelsBlackListFilterTrait {
-                          labels('on-hold ci-skip')
-                        }
-                        headWildcardFilterWithPR {
-                          includes('main master PR-*')
-                          excludes('')
-                          tagIncludes('*')
-                          tagExcludes('')
-                        }
                       }
                     }
-                  }
-
-                  orphanedItemStrategy {
-                    discardOldItems {
-                      daysToKeep(1) // Keep removed SCM heads/branch/PRs only for 1 day
-                    }
-                  }
-
-                  projectFactories {
-                    workflowMultiBranchProjectFactory {
-                      scriptPath('Jenkinsfile_k8s')
-                    }
-                  }
-
-                  buildStrategies {
-                    buildAnyBranches {
-                      strategies {
-                        buildChangeRequests {
-                          ignoreTargetOnlyChanges(true)
-                          ignoreUntrustedChanges(true)
-                        }
-                        buildRegularBranches()
-                        buildTags {
-                          atLeastDays("0")
-                          atMostDays("7")
-                        }
+                    configure { node ->
+                      def traits = node / navigators / 'org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator' / traits
+                      // Not discovered by Job-DSL: need to be configured as raw-XML
+                      traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
+                        strategyId(1) // 1-Merging the pull request with the current target branch revision
+                        trust(class: 'org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission')
                       }
-                    }
-                  }
-
-                  configure { node ->
-                    def traits = node / navigators / 'org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator' / traits
-                    // Not discovered by Job-DSL: need to be configured as raw-XML
-                    traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
-                      strategyId(1) // 1-Merging the pull request with the current target branch revision
-                      trust(class: 'org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission')
                     }
                   }
                 }


### PR DESCRIPTION
This PR is a follow up of #1123 (read it for context) and introduces the following breaking change on infra.ci's configuration:

- Factorize all multibranch jobs on a single loop-based configuration
- Factorize all gh-org scanning jobs on a single loop-based configuration (keeping 2 separated even if the same organization)

Please note that the "K8S management" job is gonna be re-created under a new URL, which is the breaking change. The older one has been renamed and disabled, and should be deleted only after 1 week (to allow rollback if required)