### PR TITLE
fix: Disable jenkins.io job in infra.ci as we rollbacked the deployment process

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -298,7 +298,7 @@ jenkins:
           jobs:
             - script: >
                 [
-                  ['Docker Builds', 'jenkins-infra', 'docker-.*|^jenkins.io$'],
+                  ['Docker Builds', 'jenkins-infra', 'docker-.*$'],
                   ['Terraform Jobs', 'jenkins-infra', 'aws|datadog$'],
                 ].each { config ->
                   organizationFolder(config[0]) {


### PR DESCRIPTION
The build on infra.ci of the `jenkins.io` is a tentative for a new "way" of doing it (by building Docker images).
But alas, we had to rollback this "new" way time to fix the failing steps.

This commit remove the job as we are not currently working on it and because it generates false positive Github checks for contributors.

cc @daniel-beck 
