### PR TITLE
Feat: prepare migration from (legacy)nginx-ingress to (tmp)ingress-nginx

### DIFF
--- a/helmfile.d/nginx-ingress.tmp.yaml
+++ b/helmfile.d/nginx-ingress.tmp.yaml
@@ -43,7 +43,7 @@ releases:
         # I doubt we need it at the moment, hence this comment.
         # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-geoip2
         use-geoip2: "true"
-      ingressClass: tmp-public-ingress
+      ingressClass: public-ingress
       service:
         annotations:
           service.beta.kubernetes.io/azure-load-balancer-internal: false
@@ -95,7 +95,7 @@ releases:
         # I doubt we need it at the moment, hence this comment.
         # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-geoip2
         use-geoip2: "true"
-      ingressClass: tmp-private-nginx
+      ingressClass: nginx
       service:
         annotations:
           service.beta.kubernetes.io/azure-load-balancer-internal: true

--- a/helmfile.d/nginx-ingress.tmp.yaml
+++ b/helmfile.d/nginx-ingress.tmp.yaml
@@ -43,6 +43,7 @@ releases:
         # I doubt we need it at the moment, hence this comment.
         # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-geoip2
         use-geoip2: "true"
+      replicaCount: 2
       ingressClass: public-ingress
       service:
         annotations:
@@ -95,6 +96,7 @@ releases:
         # I doubt we need it at the moment, hence this comment.
         # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-geoip2
         use-geoip2: "true"
+      replicaCount: 2
       ingressClass: nginx
       service:
         annotations:


### PR DESCRIPTION
Context: https://hackmd.io/cH4rbENeSOGLHD3rAgnXqQ

This PR introduces the following changes:

* Enable high availability by ensuring 2 replicas. Even with a well defined Kube deployment system which ensures a proper migration from 1 pod to another (always 1 up), there can be "hard failures", so we set the replicas to 2.
  ** Impact: it adds a new resource "PodDisruptionBudget" for each of the 2 controllers
* Define the same "ingressclass" for the 2 new (tmp)ingress-nginx controllers for a seamless migration