### PR TITLE
fix: revert infra.ci config to remove jenkins.io builds

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -302,7 +302,7 @@ jenkins:
             # List of GH Org. Folders, add your own as another map (or append existing repoPattern)
             - script: >
                 [
-                  [ name: 'Docker Builds', GHOrganization: 'jenkins-infra', repoPattern: 'docker-.*|^jenkins.io$', jenkinsfilePath: 'Jenkinsfile_k8s'],
+                  [ name: 'Docker Builds', GHOrganization: 'jenkins-infra', repoPattern: 'docker-.*$', jenkinsfilePath: 'Jenkinsfile_k8s'],
                   [ name: 'Terraform Jobs', GHOrganization: 'jenkins-infra', repoPattern: 'aws|datadog$', jenkinsfilePath: 'Jenkinsfile_k8s'],
                 ].each { config ->
                   organizationFolder(config.name) {


### PR DESCRIPTION
The changes from #1133 were overriden by #1126 . Still not sure how this could have happened (but since we work with squash merged PR, the conflict management behavior can be the culprit here)