### PR TITLE
Bugfix: factorize nginx helm repo to fix main build

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -79,7 +79,7 @@ pipeline {
             stage('Yaml Lint') {
               steps {
                 container('yamllint') {
-                  sh 'yamllint --config-file yamllint.config config/default config/publick8s'
+                  sh 'yamllint --config-file yamllint.config config/default config/publick8s config/cik8s'
                 }
               }
             }

--- a/helmfile.d/00-repositories.yaml
+++ b/helmfile.d/00-repositories.yaml
@@ -7,3 +7,5 @@ repositories:
     url: https://grafana.github.io/loki/charts
   - name: stable
     url: https://charts.helm.sh/stable
+  - name: ingress-nginx
+    url: https://kubernetes.github.io/ingress-nginx

--- a/helmfile.d/nginx-ingress.tmp.yaml
+++ b/helmfile.d/nginx-ingress.tmp.yaml
@@ -1,6 +1,3 @@
-repositories:
-- name: ingress-nginx
-  url: https://kubernetes.github.io/ingress-nginx
 releases:
 - name: tmp-public-nginx-ingress
   chart: ingress-nginx/ingress-nginx

--- a/helmfile.d/nginx-ingress.yaml
+++ b/helmfile.d/nginx-ingress.yaml
@@ -1,6 +1,3 @@
-repositories:
-- name: stable
-  url: https://kubernetes.github.io/ingress-nginx
 releases:
 - name: public-nginx-ingress
   chart: ingress-nginx/ingress-nginx


### PR DESCRIPTION
After #1137 , the "lint" step failed for the new nginx ingress, because of the repository name which was still `stable`.