### PR TITLE
fix: update public IP of trusted to allow incoming ldap access

### DIFF
--- a/config/default/ldap.yaml
+++ b/config/default/ldap.yaml
@@ -12,7 +12,7 @@ service:
     - '140.211.9.94/32'       # 107 accept inbound LDAPS request from puppet.jenkins.io puppet.jenkins.io
     - '140.211.9.32/32'       # 107 accept inbound LDAPS request from Confluence wiki.jenkins-ci.org
     - '140.211.9.2/32'        # 107 accept inbound LDAPS request from JIRA issues.jenkins-ci.org
-    - '3.91.179.67/32'        # 107 accept inbound LDAPS from trusted-ci
+    - '3.209.43.20/32'        # 107 accept inbound LDAPS from trusted-ci
     - '52.71.231.250/32'      # 107 accept inbound LDAPS from ci
     - '104.209.251.202/32'    # accept inbound LDAPS from vpn.jenkins.io
     - '104.210.5.242/32'      # accept inbound LDAPS from cert-ci


### PR DESCRIPTION
Please note that this new public IP is an elastic IP so we can reboot trusted.ci whenever we need