### PR TITLE
Fix: configuration of Windows Kubernetes agents for infra.ci and release.ci

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -197,15 +197,21 @@ jenkins:
                           alwaysPullImage: true
                     - name: jnlp-windows
                       nodeSelector: "kubernetes.io/os=windows"
+                      instanceCap: 5 # Usual sizing is 2 pods per Windows node, and max 3 windows nodes
+                      instanceCapStr: "5"
                       containers:
                         - name: jnlp
                           image: "jenkins/inbound-agent:windowsservercore-1809"
+                          command: "powershell"
+                          args: "Start-Sleep 999999"
                           resourceLimitCpu: "500m"
-                          resourceLimitMemory: "512Mi"
+                          resourceLimitMemory: "1024Mi"
                           resourceRequestCpu: "500m"
-                          resourceRequestMemory: "512Mi"
+                          resourceRequestMemory: "1024Mi"
                           args: "1d"
                           alwaysPullImage: true
+                          workingDir: "C:\\Users\\jenkins"
+                      yamlMergeStrategy: "override"
                       yaml: |-
                         spec:
                           tolerations:

--- a/config/default/jenkins-release.yaml
+++ b/config/default/jenkins-release.yaml
@@ -174,15 +174,21 @@ jenkins:
                           alwaysPullImage: true
                     - name: jnlp-windows
                       nodeSelector: "kubernetes.io/os=windows"
+                      instanceCap: 5 # Usual sizing is 2 pods per Windows node, and max 3 windows nodes
+                      instanceCapStr: "5"
                       containers:
                         - name: jnlp
                           image: "jenkins/inbound-agent:windowsservercore-1809"
+                          command: "powershell"
+                          args: "Start-Sleep 999999"
                           resourceLimitCpu: "500m"
                           resourceLimitMemory: "1024Mi"
                           resourceRequestCpu: "500m"
                           resourceRequestMemory: "1024Mi"
                           args: "1d"
                           alwaysPullImage: true
+                          workingDir: "C:\\Users\\jenkins"
+                      yamlMergeStrategy: "override"
                       yaml: |-
                         spec:
                           tolerations:


### PR DESCRIPTION
Following the weekly release 2.295 which failed with Windows agents, the default pod configuration for the windows Kubernetes agents had to be fixed.

It's a follow up of the 2 following changes on the release specific Pod Templates:

- https://github.com/jenkins-infra/release/commit/2d1f11145a1490e116f323fa7fdd19877e6917bc
- https://github.com/jenkins-infra/release/commit/92dde3d7af5f869a31644a0ea65d27fe0333eacd