### PR TITLE
Fix: missing security top-level key syntax error on JCasc configuration for infra.ci

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -27,10 +27,11 @@ jenkins:
       defaultConfig: false
       configScripts:
         security: |
-          scriptApproval:
-            approvedSignatures:
-              - "method org.jenkinsci.plugins.workflow.steps.FlowInterruptedException getCauses"
-              - "new java.lang.RuntimeException java.lang.Throwable"
+          security:
+            scriptApproval:
+              approvedSignatures:
+                - "method org.jenkinsci.plugins.workflow.steps.FlowInterruptedException getCauses"
+                - "new java.lang.RuntimeException java.lang.Throwable"
         credentials: |
           credentials:
             system:


### PR DESCRIPTION
The PR #1217 introduced a syntax error, because the key `security` has to be part of the content (not only the name).