### PR TITLE
Update mirrorbits documentation for archives.jenkins.io

### DIFF
--- a/charts/mirrorbits/README.md
+++ b/charts/mirrorbits/README.md
@@ -110,7 +110,7 @@ mirrorbits add -http https://ftp.belnet.be/mirror/jenkins/ -rsync rsync://rsync.
 # Low priority mirrors
 
 ```shell
-mirrorbits add -rsync rsync://archives.jenkins.io/jenkins/ -http https://archives.jenkins.io/jenkins -sponsor-name Jenkins-infra -sponsor-url www.jenkins.io -admin-email "jenkinsci-infra@googlegroups.com" -admin-name "Jenkins" archives.jenkins.io -score -1
+mirrorbits add -rsync rsync://archives.jenkins.io/jenkins/ -http https://archives.jenkins.io/jenkins -sponsor-name Jenkins-infra -sponsor-url www.jenkins.io -admin-email "jenkinsci-infra@googlegroups.com" -admin-name "Jenkins" archives.jenkins.io -score -100
 ```
 
 ## Links


### PR DESCRIPTION
After some testing with @MarkEWaite , it appears that a score of -1 slightly favor xmission over archives.jenkins.io which is not what we want.
What we want is to be redirected to be redirected to archives.jenkins.io only if no other mirrors are available.