### PR TITLE
fix: increase falco timeout

### DIFF
--- a/helmfile.d/falco.yaml
+++ b/helmfile.d/falco.yaml
@@ -7,7 +7,7 @@ releases:
     chart: falco/falco
     version: 1.13.1
     wait: true
-    timeout: 100
+    timeout: 300
     atomic: true
     values:
       - "../config/default/falco.yaml"


### PR DESCRIPTION
The principal branch fails with the following error:

```
Upgrading release=falco, chart=falco/falco

FAILED RELEASES:
NAME
falco
in clusters/publick8s.yaml: in .helmfiles[6]: in ../helmfile.d/falco.yaml: failed processing release falco: command "/usr/local/bin/helm" exited with non-zero status:

PATH:
  /usr/local/bin/helm

ARGS:
  0: helm (4 bytes)
  1: upgrade (7 bytes)
  2: --install (9 bytes)
  3: --reset-values (14 bytes)
  4: falco (5 bytes)
  5: falco/falco (11 bytes)
  6: --version (9 bytes)
  7: 1.13.1 (6 bytes)
  8: --wait (6 bytes)
  9: --timeout (9 bytes)
  10: 100s (4 bytes)
  11: --atomic (8 bytes)
  12: --create-namespace (18 bytes)
  13: --namespace (11 bytes)
  14: falco (5 bytes)
  15: --values (8 bytes)
  16: /tmp/helmfile839262083/falco-falco-values-598dfcb845 (52 bytes)
  17: --history-max (13 bytes)
  18: 10 (2 bytes)

ERROR:
  exit status 1

EXIT STATUS
  1

STDERR:
  Error: UPGRADE FAILED: release falco failed, and has been rolled back due to atomic being set: timed out waiting for the condition

COMBINED OUTPUT:
  Error: UPGRADE FAILED: release falco failed, and has been rolled back due to atomic being set: timed out waiting for the condition
```

As falco as an explicit timeout of `100` that seems short, this PR increases the timeout to a more conventional one (given network or FS issues that can happen on a given node)