### PR TITLE
Update JFrog allowed IP

### DIFF
--- a/config/default/ldap.yaml
+++ b/config/default/ldap.yaml
@@ -2,12 +2,8 @@ service:
   type: LoadBalancer
   whitelisted_sources:
     - '10.0.32.0/19'          # Kubernetes publick8s internal IP
-    - '50.19.229.208/32'      # 106 accept inbound LDAPS request from hosted Artifactory by JFrog
-    - '50.16.203.43/32'       # 106 accept inbound LDAPS request from hosted Artifactory by JFrog (second IP)
-    - '54.236.124.56/32'      # 106 accept inbound LDAPS request from hosted Artifactory by JFrog (third IP)
-    - '104.196.52.71/32'      # 106 accept inbound LDAPS request from hosted Artifactory by JFrog (fourth IP)
-    - '104.196.31.82/32'      # 106 accept inbound LDAPS request from hosted Artifactory by JFrog (fifth IP)
-    - '35.196.34.112/32'      # 2021-06-07 accept inbould ldaps request from hosted Artifactory by JFrog
+    - '35.196.175.89/32'      # 2021-06-08 Allow new IP repo.jenkins-ci.org. The hosted Artifactory by JFrog
+    - '34.75.131.248/32'      # 2021-06-08 Allow new IP repo.jenkins-ci.org. The hosted Artifactory by JFrog
     - '73.71.177.172/32'      # 106 accept inbound LDAPS request from spambot
     - '140.211.15.101/32'     # 107 accept inbound LDAPS request from accounts app
     - '140.211.9.94/32'       # 107 accept inbound LDAPS request from puppet.jenkins.io puppet.jenkins.io


### PR DESCRIPTION
Those two IPs were shared from Jfrog and are currently working.
I need confirmation from Jfrog ops team that we don't need other IPs.

Once this PR is merged, we can re-enabled the job on infra.ci

Signed-off-by: Olivier Vernin <olivier@vernin.me>