### PR TITLE
feat: [jenkins.io] Set header "X-Content-Type-Options" to nosniff [INFRA-2998]

### DIFF
--- a/config/default/jenkinsio.yaml
+++ b/config/default/jenkinsio.yaml
@@ -12,7 +12,7 @@ ingress:
       if ( $scheme = "https" ) {
         more_clear_headers "Strict-Transport-Security";
       }
-
+      more_set_headers "X-Content-Type-Options: nosniff";
   hosts:
     - host: jenkins.io
       paths:


### PR DESCRIPTION
This PR introduces a new Header `X-Content-Type-Options` set to the value `nosniff` for all the ingress rules on the cluster `publick8s` (AKS), including jenkins.io, as per INFRA-2998.