### PR TITLE
breaking: switch datadog agents to ContainerD instead of Docker

### DIFF
--- a/config/default/datadog/datadog.yaml
+++ b/config/default/datadog/datadog.yaml
@@ -2,6 +2,7 @@ datadog:
   collectEvents: true
   leaderElection: true
   leaderLeaseDuration: 60
+  criSocketPath: /var/run/containerd/containerd.sock
   apm:
     enabled: true
   processAgent:


### PR DESCRIPTION
This PR requires the [AKS Upgrade to 1.19.x](https://hackmd.io/EDpvZx9ZS2GWgHHqWFRDfQ).

Unlike falco, the support of both docker engine and containerd does not work (the agent always fall back to containerd when both settings `dockerSocketPath` and `criSocketPath` are specified ) (ref. https://github.com/helm/charts/tree/master/stable/datadog#cri-integration).

So let's assume the following scenario: 

- Applying this change just before the upgrade, datadog agents will fail
- Start the upgrade
- After the upgrade, agents should start successfully without any human intervention

Hence the "on hold" for now

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>