### PR TITLE
fix: configure datadog agent to use TLS for dialing with kubelet

### DIFF
--- a/config/default/datadog/datadog.yaml
+++ b/config/default/datadog/datadog.yaml
@@ -11,6 +11,12 @@ datadog:
   logs:
     enabled: true
     configContainerCollectAll: true
+  kubelet:
+    host:
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
 agents:
   rbac:
     create: true


### PR DESCRIPTION
Main references that helped me for this:

* https://github.com/DataDog/integrations-core/issues/2582#issuecomment-656610443
* https://github.com/DataDog/helm-charts/blob/master/charts/datadog/README.md