### PR TITLE
fix: use templating for datadog to allow cluster-values to be used.

### DIFF
--- a/config/default/datadog/datadog.yaml.gotmpl
+++ b/config/default/datadog/datadog.yaml.gotmpl
@@ -1,4 +1,5 @@
 datadog:
+  clusterName: {{ .Values | get "datadog.clusterName" nil }}
   collectEvents: true
   leaderElection: true
   leaderLeaseDuration: 60
@@ -11,12 +12,16 @@ datadog:
   logs:
     enabled: true
     configContainerCollectAll: true
+  {{- if hasKey .Values.datadog "kubelet" }}
   kubelet:
     host:
       valueFrom:
         fieldRef:
-          fieldPath: spec.nodeName
-    hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
+          fieldPath: {{ .Values | get "datadog.kubelet.host.valueFrom.fieldRef.fieldPath" "status.hostIP" }}
+    {{- if hasKey .Values.datadog.kubelet "hostCAPath" }}
+    hostCAPath: {{ .Values | get "datadog.kubelet.hostCAPath" nil }}
+    {{- end }}
+  {{- end }}
 agents:
   rbac:
     create: true

--- a/config/publick8s/datadog.yaml
+++ b/config/publick8s/datadog.yaml
@@ -1,2 +1,8 @@
 datadog:
   clusterName: 'publick8s'
+  kubelet:
+    host:
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    hostCAPath: /etc/kubernetes/certs/kubeletserver.crt

--- a/helmfile.d/datadog.yaml
+++ b/helmfile.d/datadog.yaml
@@ -10,6 +10,6 @@ releases:
     timeout: 600
     atomic: true
     values:
-      - "../config/default/datadog/datadog.yaml"
+      - "../config/default/datadog/datadog.yaml.gotmpl"
     secrets:
       - "../secrets/config/datadog/secrets.yaml"


### PR DESCRIPTION
The principal branch is broken since the AKS 1.19 upgrade, because of #1258 and #1265 .

The main reason is that the values specified in an element of `helmfiles` are not merged into the values of a given release.
As such, the attributes `clusterName` defined in `config/publick8s/datadog.yaml` and `config/cik8s/datadog.yaml` was not used in the deployments.
This "template/merging" hell as been consequential in #1265 because it applied the publick8s' (AKS) specific settings for the kubelet (path of the cacert + hostname used instead of IP) to cik8s (EKS), making the deployment failing on cik8s.

This PR tries to hack around by defining the "default values" at release level as a go template, so it can dynamically retrieve the values from higher level.
Helmfile seems to provide a bunch of other options (check https://github.com/roboll/helmfile/blob/master/docs/writing-helmfile.md for instance) but I was not able to make it work: the documentation is missing pieces and I can't put my brain.
=> The PR is not "uber" strict around the templating (a lot of thing can go wrong: no implicit merging, no "elvis"-like opartor to test if keys exists, etc.) but it's a PoC to start fixing the issue. The proposal is to iterate and refine on the go