### PR TITLE
feat: install autoscaler to cik8s + add updatecli config but disabled [INFRA-2918]

### DIFF
--- a/clusters/cik8s.yaml
+++ b/clusters/cik8s.yaml
@@ -5,3 +5,4 @@ helmfiles:
     values:
       - "../../config/cik8s/datadog.yaml"
   - path: "../helmfile.d/jenkins-agents.yaml"
+  - path: "../helmfile.d/autoscaler.yaml"

--- a/config/cik8s/autoscaler.yaml
+++ b/config/cik8s/autoscaler.yaml
@@ -1,0 +1,15 @@
+---
+awsRegion: us-east-2
+
+rbac:
+  create: true
+  serviceAccount:
+    # This value is defined in https://github.com/jenkins-infra/aws/blob/main/locals.tf#L9
+    name: cluster-autoscaler-aws-cluster-autoscaler-chart
+    annotations:
+      # This value should match the ARN of the role created by module.iam_assumable_role_admin in irsa.tf
+      eks.amazonaws.com/role-arn: "arn:aws:iam::200564066411:role/cluster-autoscaler"
+
+autoDiscovery:
+  clusterName: jenkins-infra-eks-ENRZrfwf
+  enabled: true

--- a/helmfile.d/autoscaler.yaml
+++ b/helmfile.d/autoscaler.yaml
@@ -1,0 +1,13 @@
+repositories:
+  - name: autoscaler
+    url: https://kubernetes.github.io/autoscaler
+releases:
+  - name: autoscaler
+    namespace: autoscaler
+    chart: autoscaler/cluster-autoscaler
+    version: 9.10.4
+    wait: true
+    timeout: 300
+    atomic: true
+    values:
+      - "../config/cik8s/autoscaler.yaml"

--- a/updatecli/updatecli.d/charts/autoscaler.tpl.disable
+++ b/updatecli/updatecli.d/charts/autoscaler.tpl.disable
@@ -1,0 +1,46 @@
+title: Bump autoscaler helm chart version
+sources:
+  default:
+    kind: helmChart
+    spec:
+      url: https://kubernetes.github.io/autoscaler
+      name: cluster-autoscaler
+conditions:
+  exist:
+    name: "Autoscaler helm chart available on Registry"
+    kind: helmChart
+    spec:
+      url: https://kubernetes.github.io/autoscaler
+      name: cluster-autoscaler
+  helmfileRelease:
+    name: "autoscaler/cluster-autoscaler Helm Chart"
+    kind: yaml
+    spec:
+      file: "helmfile.d/autoscaler.yaml"
+      key: "releases[0].name"
+      value: "autoscaler"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+targets:
+  chartVersion:
+    name: "autoscaler/cluster-autoscaler Helm Chart"
+    kind: yaml
+    spec:
+      file: "helmfile.d/autoscaler.yaml"
+      key: "releases[0].version"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"


### PR DESCRIPTION
This PR installs the official cluster autoscaler chart on `cik8s` , our EKS cluster for ci.jenkins.io.

It's part of INFRA-2918 to ensure that are enough resources provided to ci.jenkins.io.

Please note that
- The installation has been done manually one time for boostrap. it means that the initial helm diff might be empty (or almost empty).
- The updateCLI config is disabled to avoid failing the initial build (has it would fail to find the YAML files). Expect a PR next week to enable updateCLI fully.