### PR TITLE
feat: enable HSTS by default on all the publick8s cluster

### DIFF
--- a/charts/uplink/values.yaml
+++ b/charts/uplink/values.yaml
@@ -40,7 +40,6 @@ ingress:
   annotations:
     kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/hsts: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
   hosts:
@@ -71,7 +70,7 @@ tolerations: []
 affinity: {}
 
 postgresql:
-  url: 
+  url:
 client:
   id: ""
   secret: ""

--- a/config/default/accountapp.yaml
+++ b/config/default/accountapp.yaml
@@ -3,7 +3,7 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "kubernetes.io/ingress.class": "public-ingress"
-    "nginx.ingress.kubernetes.io/hsts": "true"
+
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
     "nginx.ingress.kubernetes.io/affinity": "cookie"
 

--- a/config/default/captain-hook.yaml
+++ b/config/default/captain-hook.yaml
@@ -4,7 +4,7 @@ ingress:
   annotations:
     # "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "kubernetes.io/ingress.class": "public-ingress"
-    "nginx.ingress.kubernetes.io/hsts": "true"
+
     # "nginx.ingress.kubernetes.io/ssl-redirect": "true"
     # tls:
     #   - hosts:

--- a/config/default/custom-distribution-service.yaml
+++ b/config/default/custom-distribution-service.yaml
@@ -3,7 +3,7 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "kubernetes.io/ingress.class": "public-ingress"
-    "nginx.ingress.kubernetes.io/hsts": "true"
+
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
     "nginx.ingress.kubernetes.io/enable-cors": "true"
 

--- a/config/default/incrementals-publisher.yaml
+++ b/config/default/incrementals-publisher.yaml
@@ -3,7 +3,7 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "kubernetes.io/ingress.class": "public-ingress"
-    "nginx.ingress.kubernetes.io/hsts": "true"
+
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
 
   hosts:

--- a/config/default/javadoc.yaml
+++ b/config/default/javadoc.yaml
@@ -3,7 +3,7 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "kubernetes.io/ingress.class": "public-ingress"
-    "nginx.ingress.kubernetes.io/hsts": "true"
+
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
 
   hosts:

--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -589,7 +589,7 @@ jenkins:
       annotations:
         "cert-manager.io/cluster-issuer": "letsencrypt-prod"
         "kubernetes.io/ingress.class": "public-ingress"
-        "nginx.ingress.kubernetes.io/hsts": "true"
+
         "nginx.ingress.kubernetes.io/ssl-redirect": "true"
       tls:
         - hosts:

--- a/config/default/jenkinsio.yaml
+++ b/config/default/jenkinsio.yaml
@@ -9,9 +9,6 @@ ingress:
         rewrite ^/((?!patron|maven-site|jenkins.jnlp).+)$ https://www.jenkins.io/$1 permanent;
         rewrite ^/$ https://$host permanent;
       }
-      if ( $scheme = "https" ) {
-        more_clear_headers "Strict-Transport-Security";
-      }
       more_set_headers "X-Content-Type-Options: nosniff";
       more_set_headers X-Frame-Options "DENY";
   hosts:

--- a/config/default/mirrorbits.yaml
+++ b/config/default/mirrorbits.yaml
@@ -23,7 +23,6 @@ ingress:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "kubernetes.io/ingress.class": "public-ingress"
     "nginx.ingress.kubernetes.io/ssl-redirect": "false"
-    "nginx.ingress.kubernetes.io/hsts": "false"
   hosts:
     - host: get.jenkins.io
       paths:

--- a/config/default/plugin-site.yaml
+++ b/config/default/plugin-site.yaml
@@ -4,7 +4,7 @@ ingress:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "kubernetes.io/ingress.class": "public-ingress"
     "nginx.ingress.kubernetes.io/rewrite-target": /$1
-    "nginx.ingress.kubernetes.io/hsts": "true"
+
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
     "nginx.ingress.kubernetes.io/enable-cors": "true"
     "nginx.ingress.kubernetes.io/cors-allow-methods": "GET, OPTIONS"

--- a/config/default/reports.yaml
+++ b/config/default/reports.yaml
@@ -3,7 +3,7 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "kubernetes.io/ingress.class": "public-ingress"
-    "nginx.ingress.kubernetes.io/hsts": "true"
+
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
 
   hosts:

--- a/config/default/uplink.yaml
+++ b/config/default/uplink.yaml
@@ -3,7 +3,7 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "kubernetes.io/ingress.class": "public-ingress"
-    "nginx.ingress.kubernetes.io/hsts": "true"
+
     "nginx.ingress.kubernetes.io/rewrite-target": /
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
   hosts:

--- a/helmfile.d/nginx-ingress.yaml
+++ b/helmfile.d/nginx-ingress.yaml
@@ -37,6 +37,11 @@ releases:
             # I doubt we need it at the moment, hence this comment.
             # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-geoip2
             use-geoip2: "true"
+            hsts: "true"
+            hsts-preload: "true"
+            hsts-include-subdomains: "true"
+            # Should be 2 years as per https://hstspreload.org/
+            hsts-max-age: "86400" # 24 hours, as a first gradual HSTS deployment - see INFRA-2998
           replicaCount: 2
           ingressClass: public-ingress
           service:


### PR DESCRIPTION
This PR comes from INFRA-2998 and aims at enabling HSTS globally on the public ingress of the cluster `publick8s` by default, unless disabled per ingress rules.

It reverts the content of https://github.com/jenkins-infra/charts/pull/98 as tipped by @timja , now that we have HTTPS mirrors (and that the charts allows disabling HSTS per ingress rule).

The HSTS values are the default recommended per https://hstspreload.org/.

⚠️ Please note that this PR, once merged and deployed, might break some usages (clictracking, stats, cross sites). It is a non easy topics, so if we breaks usages, we'll have to avoid disabling it and instead fine tune (per website, or header values).
=> It means that a torough reveiw is required