### PR TITLE
feat: Bump loki and promtail to latest version + move the central grafana chart repository 

### DIFF
--- a/helmfile.d/00-repositories.yaml
+++ b/helmfile.d/00-repositories.yaml
@@ -3,8 +3,9 @@ repositories:
     url: https://charts.helm.sh/incubator
   - name: jetstack
     url: https://charts.jetstack.io
-  - name: loki
-    url: https://grafana.github.io/loki/charts
+  - name: grafana
+    # For grafana but also loki and promtail
+    url: https://grafana.github.io/helm-charts
   - name: stable
     url: https://charts.helm.sh/stable
   - name: ingress-nginx

--- a/helmfile.d/00-repositories.yaml
+++ b/helmfile.d/00-repositories.yaml
@@ -6,6 +6,9 @@ repositories:
   - name: grafana
     # For grafana but also loki and promtail
     url: https://grafana.github.io/helm-charts
+  - name: loki
+    # For grafana but also loki and promtail
+    url: https://grafana.github.io/helm-charts
   - name: stable
     url: https://charts.helm.sh/stable
   - name: ingress-nginx

--- a/helmfile.d/00-repositories.yaml
+++ b/helmfile.d/00-repositories.yaml
@@ -6,9 +6,6 @@ repositories:
   - name: grafana
     # For grafana but also loki and promtail
     url: https://grafana.github.io/helm-charts
-  - name: loki
-    # For grafana but also loki and promtail
-    url: https://grafana.github.io/helm-charts
   - name: stable
     url: https://charts.helm.sh/stable
   - name: ingress-nginx

--- a/helmfile.d/grafana.yaml
+++ b/helmfile.d/grafana.yaml
@@ -1,6 +1,3 @@
-repositories:
-  - name: grafana
-    url: https://grafana.github.io/helm-charts
 releases:
   - name: grafana
     namespace: grafana

--- a/helmfile.d/loki.yaml
+++ b/helmfile.d/loki.yaml
@@ -2,7 +2,7 @@ releases:
   - name: loki
     namespace: loki
     chart: loki/loki
-    version: 2.1.1
+    version: 2.6.0
     wait: true
     timeout: 300
     force: false

--- a/helmfile.d/loki.yaml
+++ b/helmfile.d/loki.yaml
@@ -1,6 +1,3 @@
-repositories:
-  - name: loki
-    url: https://grafana.github.io/loki/charts
 releases:
   - name: loki
     namespace: loki

--- a/helmfile.d/loki.yaml
+++ b/helmfile.d/loki.yaml
@@ -1,7 +1,7 @@
 releases:
   - name: loki
     namespace: loki
-    chart: loki/loki
+    chart: grafana/loki
     version: 2.6.0
     wait: true
     timeout: 300

--- a/helmfile.d/promtail.yaml
+++ b/helmfile.d/promtail.yaml
@@ -1,6 +1,3 @@
-repositories:
-  - name: loki
-    url: https://grafana.github.io/loki/charts
 releases:
   - name: promtail
     namespace: loki

--- a/helmfile.d/promtail.yaml
+++ b/helmfile.d/promtail.yaml
@@ -2,7 +2,7 @@ releases:
   - name: promtail
     namespace: loki
     chart: loki/promtail
-    version: 2.0.2
+    version: 3.7.0
     wait: true
     timeout: 300
     force: false

--- a/helmfile.d/promtail.yaml
+++ b/helmfile.d/promtail.yaml
@@ -1,7 +1,7 @@
 releases:
   - name: promtail
     namespace: loki
-    chart: loki/promtail
+    chart: grafana/promtail
     version: 3.7.0
     wait: true
     timeout: 300

--- a/updatecli/updatecli.d/charts/grafana-loki.tpl
+++ b/updatecli/updatecli.d/charts/grafana-loki.tpl
@@ -4,7 +4,7 @@ sources:
   default:
     kind: helmChart
     spec:
-      url: https://grafana.github.io/loki/charts
+      url: https://grafana.github.io/helm-charts
       name: loki
 conditions:
   helmfileRelease:

--- a/updatecli/updatecli.d/charts/grafana-promtail.tpl
+++ b/updatecli/updatecli.d/charts/grafana-promtail.tpl
@@ -5,7 +5,7 @@ sources:
   default:
     kind: helmChart
     spec:
-      url: https://grafana.github.io/loki/charts
+      url: https://grafana.github.io/helm-charts
       name: promtail
 conditions:
   helmfileRelease:


### PR DESCRIPTION
When applying the charts for promtail and loki, helmfile reports a warning that the charts are deprecated.

It appears that the chart repository have been moved since 12/2020 (as per the admonition on https://grafana.com/docs/loki/latest/installation/helm/).

This PR ensures that the correct chart repository is defined once so that both promtail and loki are using it.
Please note that it's the same repository as grafana.


This change made mandatory to bump the 2 charts for loki and promtail as the "old" versions we were using does not exist on the new repository.

Please note that the diff for promtail isconsequent as the bump is huge.