### PR TITLE
fix: correct custom HTTP header syntax for jenkins.io [INFRA-2998]

### DIFF
--- a/config/default/jenkinsio.yaml
+++ b/config/default/jenkinsio.yaml
@@ -10,7 +10,7 @@ ingress:
         rewrite ^/$ https://$host permanent;
       }
       more_set_headers "X-Content-Type-Options: nosniff";
-      more_set_headers X-Frame-Options "DENY";
+      more_set_headers "X-Frame-Options: DENY";
   hosts:
     - host: jenkins.io
       paths:


### PR DESCRIPTION
Signed-off-by: Damien Duportal <damien.duportal@gmail.com>