### PR TITLE
Update promtail loki configuration

### DIFF
--- a/config/default/promtail.yaml
+++ b/config/default/promtail.yaml
@@ -7,7 +7,6 @@ resources:
     cpu: 100m
     memory: 128Mi
 
-loki:
-  serviceName: "loki"
+config:
+  lokiAddress: http://loki:3100/loki/api/v1/push
   servicePort: 3100
-  serviceScheme: http


### PR DESCRIPTION
Loki client configuration key changed in the recent version of the promtail helm chart.
As defined [here](https://github.com/grafana/helm-charts/blob/e13e3b4971c5f2f9da908c0cb8db22bcc818f0ba/charts/promtail/values.yaml#L235) the URL doesn't match our Loki configuration.

I manually applied the change to the production server and we can now look at the data on our Grafana instance
 
Signed-off-by: Olivier Vernin <olivier@vernin.me>