### PR TITLE
Add allowed IP to ldap service firewall

### DIFF
--- a/config/default/ldap.yaml
+++ b/config/default/ldap.yaml
@@ -17,3 +17,5 @@ service:
     - '52.167.253.43/32'      # Accept inbound LDAPS from public.aks.jenkins.io
     - '34.211.101.61/32'      # Accept inbound connections from Linux Foundation test machine
     - '44.240.22.235/32'      # Accept inbound connections from Linux Foundation prod machine
+    - '20.75.10.224/29'       # Accept inbound connections from publick8s public IPs
+    - '40.85.158.127/32'      # **Temporary** accept inbound connections olblak-confluence hosted on jenkins azure account. Please remove this entry once the machine is deleted


### PR DESCRIPTION
* Allow ldap connections from the new public8s IP range
* Allow inbound connections from the *temporary* confluence backup machine

Signed-off-by: Olivier Vernin <olivier@vernin.me>