### PR TITLE
Increase timeout when deploying keycloak

### DIFF
--- a/helmfile.d/keycloak.yaml
+++ b/helmfile.d/keycloak.yaml
@@ -8,7 +8,7 @@ releases:
     chart: codecentric/keycloak
     version: "15.0.0"
     wait: true
-    timeout: 300
+    timeout: 600
     atomic: true
     values:
       - "../config/default/keycloak.yaml"


### PR DESCRIPTION
Apparently, 5 minutes is not enough for keycloak to be ready.

Signed-off-by: Olivier Vernin <olivier@vernin.me>