### PR TITLE
fix: update the packer azure SP client_id credential setup for infra.ci

### DIFF
--- a/config/default/jenkins-infra.yaml
+++ b/config/default/jenkins-infra.yaml
@@ -185,8 +185,8 @@ jenkins:
                   - string:
                       scope: GLOBAL
                       id: "packer-azure-client-id"
-                      secret: "${PACKER_AZURE_CLIENT_SECRET_ID}"
-                      description: Azure client secret ID for the Service Principal "packer"
+                      secret: "${PACKER_AZURE_CLIENT_ID}"
+                      description: Azure client ID for the Service Principal "packer"
                   - string:
                       scope: GLOBAL
                       id: "packer-azure-client-secret"


### PR DESCRIPTION
I mixed up (in #1444) the "secret ID" and "client ID" for the Service Principal account `packer`. This PR fixes the setup (and the secret has been updated in the private repo).

Build https://infra.ci.jenkins.io/blue/organizations/jenkins/packer-images/detail/PR-85/5/pipeline/193 was triggered manually to test the "new" credential value, to ensure that it works.