### PR TITLE
Update accountapp docker image to the latest one

### DIFF
--- a/charts/accountapp/values.yaml
+++ b/charts/accountapp/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: jenkinsciinfra/account-app
-  tag: 100-buildc7216a
+  tag: 169-buildca55e3
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
It appears that we didn't update this image for a while but it's needed for https://github.com/jenkins-infra/account-app/pull/133
