### PR TITLE
Update jira url used by accountapp

### DIFF
--- a/charts/accountapp/values.yaml
+++ b/charts/accountapp/values.yaml
@@ -61,7 +61,7 @@ ldap:
 jira:
   username: accountapp
   password:
-  url: https://issues.jenkins-ci.org/
+  url: https://issues.jenkins.io/
 
 seats: 2
 seniority: 12


### PR DESCRIPTION
Well, I forgot this one
This PR is another attempt to fix 
![image](https://user-images.githubusercontent.com/2360224/135112655-8bcfa920-67fd-4b6f-90f7-8d5f3df2750d.png)


