### PR TITLE
Add keycloak affinity based on cookies

### DIFF
--- a/config/default/keycloak.yaml
+++ b/config/default/keycloak.yaml
@@ -6,6 +6,7 @@ ingress:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "kubernetes.io/ingress.class": "nginx"
     "nginx.ingress.kubernetes.io/proxy-body-size": "500m"
+    "nginx.ingress.kubernetes.io/affinity": "cookie"
   rules:
     - host: admin.accounts.jenkins.io
       paths:

--- a/config/default/keycloak.yaml
+++ b/config/default/keycloak.yaml
@@ -42,10 +42,10 @@ extraVolumes: |
     emptyDir: {}
 resources:
   limits:
-    cpu: 1000m
+    cpu: 1500m
     memory: 2048Mi
   requests:
-    cpu: 1000m
+    cpu: 1500m
     memory: 2048Mi
 
 ## Database Setup


### PR DESCRIPTION
* Add connection affinity to avoid authentication being broken when redirected to the second pod
* Increase cpu allocated to keycloak, according to grafana memory doesn't seem to be an issue