### PR TITLE
chore [datadog] refinements and deprecation

### DIFF
--- a/config/default/datadog/datadog.yaml.gotmpl
+++ b/config/default/datadog/datadog.yaml.gotmpl
@@ -5,7 +5,7 @@ datadog:
   leaderLeaseDuration: 60
   criSocketPath: /var/run/containerd/containerd.sock
   apm:
-    enabled: true
+    portEnabled: true
   processAgent:
     enabled: true
     processCollection: true

--- a/helmfile.d/datadog.yaml
+++ b/helmfile.d/datadog.yaml
@@ -7,7 +7,7 @@ releases:
     chart: datadog/datadog
     version: 2.22.13
     wait: true
-    timeout: 600
+    timeout: 1200
     atomic: true
     values:
       - "../config/default/datadog/datadog.yaml.gotmpl"


### PR DESCRIPTION
This PR introduces the following non functional changes:

- Update a deprecated directive for datadog chart (see commit message for details)
- increase chart timeout to avoid erroring when cik8s is heavily scaling