### PR TITLE
fix(wiki) bump chart to allow /status monitoring + set to 2 replicas

### DIFF
--- a/config/default/wiki.yaml
+++ b/config/default/wiki.yaml
@@ -38,3 +38,5 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
+
+replicaCount: 2

--- a/helmfile.d/wiki.yaml
+++ b/helmfile.d/wiki.yaml
@@ -2,7 +2,7 @@ releases:
   - name: wiki
     namespace: wiki
     chart: jenkins-infra/wiki
-    version: 0.2.2
+    version: 0.3.0
     wait: false
     values:
       - "../config/default/wiki.yaml"


### PR DESCRIPTION
Signed-off-by: Damien Duportal <damien.duportal@gmail.com>