### PR TITLE
feat(cik8s) ensure that spot instance are autoscaled and cleaned up safely (INFRA-3104)

### DIFF
--- a/clusters/cik8s.yaml
+++ b/clusters/cik8s.yaml
@@ -6,3 +6,4 @@ helmfiles:
       - "../../config/cik8s/datadog.yaml"
   - path: "../helmfile.d/jenkins-agents.yaml"
   - path: "../helmfile.d/autoscaler.yaml"
+  - path: "../helmfile.d/aws-node-termination-handler.yaml"

--- a/config/cik8s/autoscaler.yaml
+++ b/config/cik8s/autoscaler.yaml
@@ -1,6 +1,10 @@
 ---
 awsRegion: us-east-2
 
+nodeSelector:
+  node.kubernetes.io/lifecycle: normal
+  node.kubernetes.io/instance-type: t3a.xlarge
+
 rbac:
   create: true
   serviceAccount:

--- a/config/cik8s/aws-node-termination-handler.yaml
+++ b/config/cik8s/aws-node-termination-handler.yaml
@@ -1,0 +1,6 @@
+---
+awsRegion: us-east-2
+
+nodeSelector:
+  node.kubernetes.io/lifecycle: normal
+  node.kubernetes.io/instance-type: t3a.xlarge

--- a/helmfile.d/aws-node-termination-handler.yaml
+++ b/helmfile.d/aws-node-termination-handler.yaml
@@ -1,0 +1,13 @@
+repositories:
+  - name: eks
+    url: https://aws.github.io/eks-charts
+releases:
+  - name: aws-node-termination-handler
+    namespace: eks
+    chart: eks/aws-node-termination-handler
+    version: 0.16.0
+    wait: true
+    timeout: 300
+    atomic: true
+    values:
+      - "../config/cik8s/aws-node-termination-handler.yaml"


### PR DESCRIPTION
- The autoscaler charts is "forced" to the tiny instances that are small, cheap and always available (ondemand pool only for such use cases)
- A new charts is installed to cleanly react on spot de-allocation