### PR TITLE
fix(jenkins-infra) stop using cluster-admin role for helmfile

### DIFF
--- a/PodTemplates.yaml
+++ b/PodTemplates.yaml
@@ -92,5 +92,3 @@ spec:
       securityContext:
         privileged: false
       tty: true
-  restartPolicy: "Never"
-  serviceAccount: "cluster-admin"

--- a/helmfile.d/jenkins-infra.yaml
+++ b/helmfile.d/jenkins-infra.yaml
@@ -1,21 +1,10 @@
 repositories:
   - name: jenkins
     url: https://charts.jenkins.io
-  - name: jenkins-infra
-    url: https://jenkins-infra.github.io/public-charts
 releases:
   - name: jenkins-infra
     chart: jenkins/jenkins
     version: 3.8.8
     namespace: jenkins-infra
-    set:
-      - name: namespace
-        value: jenkins-infra
     values:
     - ../config/jenkins-infra.yaml
-  - name: jenkins-infra-additional
-    chart: jenkins-infra/jenkins-additional
-    version: 0.0.1
-    namespace: jenkins-infra
-    values:
-    - ../config/jenkins-infra-additional.yaml


### PR DESCRIPTION
- infra.ci.jenkins.io does not need addition secrets/svc account except the default from the official Jernkins Helm Chart
- No need to maintain backward compatibility with helm v2: namespace is only needed as level 0 key
- Removing unsued jenkins-addition from jenkins-infra's helmfile