### PR TITLE
fix(jenkinsio) use last chart version to get rid of nginx's

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -146,7 +146,7 @@ releases:
   - name: jenkinsio
     namespace: jenkinsio
     chart: jenkins-infra/jenkinsio
-    version: 0.0.23
+    version: 0.1.3
     values:
       - "../config/jenkinsio.yaml"
     secrets:


### PR DESCRIPTION
ingress.kubernetes.io/configuration-snippet annotation

https://github.com/kubernetes/ingress-nginx/issues/7837#issuecomment-969750366

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>