### PR TITLE
fix: correct helmfile target for jenkins-kubernetes-agent updatecli manifest

### DIFF
--- a/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for jenkins kubernetes agent"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/cik8s.yaml
       matchPattern: 'chart: jenkins-infra\/jenkins-kubernetes-agents((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/jenkins-kubernetes-agents${1}version: {{ source `lastChartVersion` }}'
     scm:


### PR DESCRIPTION
Fixes the error noticed in [updatecli logs](https://infra.ci.jenkins.io/blue/organizations/jenkins/charts/detail/main/1478/pipeline/117#step-118-log-941):
```
updateChartVersion
------------------
ERROR: Something went wrong in target "updateChartVersion" :
ERROR: No line matched in the file "/tmp/updatecli/jenkins-infra/charts/clusters/publick8s.yaml" for the pattern "chart: jenkins-infra\\/jenkins-kubernetes-agents((\\r\\n|\\r|\\n)(\\s+))version: .*"

```