### PR TITLE
fix: scaledown keycloak from 2 to 1 replica

### DIFF
--- a/config/keycloak.yaml
+++ b/config/keycloak.yaml
@@ -1,4 +1,4 @@
-replicas: 2
+replicas: 1
 
 ingress:
   enabled: true


### PR DESCRIPTION
We're scaling down Keycloak because the session sharing isn't working as intended.