### PR TITLE
Revert "[updatecli] Bump keycloak helm chart version"

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -259,7 +259,7 @@ releases:
   - name: keycloak # Admin: https://admin.accounts.jenkins.io/auth/admin
     namespace: keycloak
     chart: codecentric/keycloak
-    version: 16.0.4
+    version: 15.1.0
     timeout: 600
     values:
       - "../config/keycloak.yaml"


### PR DESCRIPTION
Reverts jenkins-infra/charts#1798 until this PR is merged: https://github.com/codecentric/helm-charts/pull/514